### PR TITLE
fix: update footer title to 'Hauling Services Directory'

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
           <div>
             <Link href="/" className="flex items-center gap-2 font-bold text-lg">
               <Truck className="h-5 w-5 text-primary" />
-              <span>HaulFind</span>
+              <span>Hauling Services Directory</span>
             </Link>
             <p className="text-sm text-muted-foreground mt-1">
               Nationwide directory for hauling &amp; removal services.
@@ -31,7 +31,7 @@ export function Footer() {
         </div>
 
         <p className="text-xs text-muted-foreground mt-8">
-          &copy; {new Date().getFullYear()} HaulFind. All rights reserved.
+          &copy; {new Date().getFullYear()} Hauling Services Directory. All rights reserved.
         </p>
       </Container>
     </footer>


### PR DESCRIPTION
Fixes #4

Updated the footer title from "HaulFind" to "Hauling Services Directory" in both the main title link and copyright text.

Generated with [Claude Code](https://claude.ai/code)