### PR TITLE
fix: capture full business details from CSV and improve web scraper

### DIFF
--- a/src/components/listings/ListingDetail.tsx
+++ b/src/components/listings/ListingDetail.tsx
@@ -48,6 +48,30 @@ export function ListingDetail({ business }: ListingDetailProps) {
         {business.services && business.services.length > 0 && (
           <ServicesList services={business.services} />
         )}
+
+        {business.attributes && Object.keys(business.attributes).length > 0 && (
+          <div className="border rounded-xl p-5 bg-muted/30 space-y-4">
+            {Object.entries(business.attributes).map(([category, items]) => (
+              <div key={category}>
+                <h3 className="text-sm font-semibold text-foreground mb-2">{category}</h3>
+                <ul className="space-y-1">
+                  {Object.entries(items).map(([label, value]) => (
+                    <li key={label} className="flex items-center gap-2 text-sm">
+                      {value ? (
+                        <span className="text-green-600" aria-hidden="true">✓</span>
+                      ) : (
+                        <span className="text-muted-foreground" aria-hidden="true">✗</span>
+                      )}
+                      <span className={value ? 'text-foreground' : 'text-muted-foreground'}>
+                        {label}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Right: Contact/Meta */}

--- a/src/lib/seed/import-real-data.ts
+++ b/src/lib/seed/import-real-data.ts
@@ -32,6 +32,8 @@ interface ProcessedBusiness {
   booking_url?: string
   working_hours?: Record<string, string | null>
   social_media?: Record<string, string>
+  services?: Array<{ name: string; source: string }>
+  attributes?: Record<string, Record<string, boolean>>
 }
 
 // US state abbreviations to full names mapping
@@ -90,6 +92,66 @@ function parseSocialMedia(row: ExcelRowData): Record<string, string> | undefined
   if (youtube)   result.youtube   = String(youtube)
 
   return Object.keys(result).length > 0 ? result : undefined
+}
+
+/**
+ * Parses the 'about' JSON field from Outscraper format.
+ * e.g. {"Service options": {"Onsite services": true}, "Accessibility": {"Wheelchair accessible entrance": true}}
+ * Returns services (from 'Service options') and attributes (all other categories).
+ */
+function parseAboutField(about: any): {
+  services: Array<{ name: string; source: 'google' }>
+  attributes: Record<string, Record<string, boolean>> | undefined
+} {
+  if (!about) return { services: [], attributes: undefined }
+
+  try {
+    const parsed = typeof about === 'string' ? JSON.parse(about) : about
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { services: [], attributes: undefined }
+    }
+
+    const services: Array<{ name: string; source: 'google' }> = []
+    const attributes: Record<string, Record<string, boolean>> = {}
+
+    for (const [category, items] of Object.entries(parsed)) {
+      if (typeof items !== 'object' || items === null || Array.isArray(items)) continue
+
+      if (category === 'Service options') {
+        // Extract individual service options that are enabled
+        for (const [key, value] of Object.entries(items as Record<string, boolean>)) {
+          if (value === true) {
+            services.push({ name: key, source: 'google' })
+          }
+        }
+      } else {
+        // Store everything else as structured attributes (Accessibility, Amenities, etc.)
+        attributes[category] = items as Record<string, boolean>
+      }
+    }
+
+    return {
+      services,
+      attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
+    }
+  } catch {
+    return { services: [], attributes: undefined }
+  }
+}
+
+/**
+ * Parses the 'subtypes' column into service items.
+ * e.g. "Junk removal service, Debris removal service" → [{name: "Junk removal service", source: "google"}]
+ */
+function parseSubtypes(subtypes: any): Array<{ name: string; source: 'google' }> {
+  if (!subtypes) return []
+  const raw = String(subtypes).trim()
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+    .map(name => ({ name, source: 'google' as const }))
 }
 
 /**
@@ -166,14 +228,29 @@ function parseExcelFile(filePath: string): { businesses: ProcessedBusiness[]; ra
       seenSlugs.set(baseSlug, count + 1)
       const slug = count === 0 ? baseSlug : `${baseSlug}-${count + 1}`
 
-      // Build description: prefer 'about' column (richer), fall back to 'description'
-      const about       = getFieldValue(row, ['about'])
-      const description = getFieldValue(row, ['description', 'details', 'services'])
-      const combinedDescription = about
-        ? String(about)
-        : description
-          ? String(description)
-          : undefined
+      // Build description: prefer website_description (plain text), fall back to website_title
+      // Do NOT use the raw 'about' JSON as description — that is parsed separately below
+      const websiteDescription = getFieldValue(row, ['website_description'])
+      const websiteTitle       = getFieldValue(row, ['website_title'])
+      const plainDescription   = getFieldValue(row, ['description', 'details'])
+      const combinedDescription = websiteDescription
+        ? String(websiteDescription)
+        : websiteTitle
+          ? String(websiteTitle)
+          : plainDescription
+            ? String(plainDescription)
+            : undefined
+
+      // Parse 'about' JSON field for services and structured attributes
+      const aboutRaw = getFieldValue(row, ['about'])
+      const { services: aboutServices, attributes } = parseAboutField(aboutRaw)
+
+      // Parse 'subtypes' column as fallback services if no service options in 'about'
+      const subtypesRaw = getFieldValue(row, ['subtypes'])
+      const subtypeServices = parseSubtypes(subtypesRaw)
+
+      // Combine: use about services first, fall back to subtypes
+      const services = aboutServices.length > 0 ? aboutServices : subtypeServices
 
       // Extract ratings directly from CSV
       const ratingRaw      = getFieldValue(row, ['rating'])
@@ -204,6 +281,8 @@ function parseExcelFile(filePath: string): { businesses: ProcessedBusiness[]; ra
         booking_url:   getFieldValue(row, ['booking_appointment_link']) || undefined,
         working_hours: parseWorkingHours(getFieldValue(row, ['working_hours'])),
         social_media:  parseSocialMedia(row),
+        services:      services.length > 0 ? services : undefined,
+        attributes:    attributes,
       }
 
       businesses.push(business)
@@ -304,21 +383,44 @@ async function importRealData(excelFilePath: string) {
 
     console.log(`✅ Inserted ${insertedBusinesses?.length ?? 0} businesses into database`)
 
-    // Insert primary photos from CSV 'photo' column into business_images
+    // Insert primary photos and logos from CSV columns into business_images
     if (insertedBusinesses && insertedBusinesses.length > 0) {
-      const imageRows = insertedBusinesses
-        .map((biz, i) => {
-          const photoUrl = getFieldValue(rawRows[i], ['photo'])
-          if (!photoUrl || typeof photoUrl !== 'string' || !photoUrl.startsWith('http')) return null
-          return {
+      const imageRows: Array<{
+        business_id: string
+        url: string
+        alt_text: string
+        is_primary: boolean
+        sort_order: number
+      }> = []
+
+      for (let i = 0; i < insertedBusinesses.length; i++) {
+        const biz = insertedBusinesses[i]
+        const row = rawRows[i]
+
+        // Primary photo
+        const photoUrl = getFieldValue(row, ['photo'])
+        if (photoUrl && typeof photoUrl === 'string' && photoUrl.startsWith('http')) {
+          imageRows.push({
             business_id: biz.id,
             url: String(photoUrl),
             alt_text: `${biz.name} photo`,
             is_primary: true,
             sort_order: 0,
-          }
-        })
-        .filter(Boolean)
+          })
+        }
+
+        // Logo image (stored as non-primary, sort_order 100 to separate from photos)
+        const logoUrl = getFieldValue(row, ['logo'])
+        if (logoUrl && typeof logoUrl === 'string' && logoUrl.startsWith('http')) {
+          imageRows.push({
+            business_id: biz.id,
+            url: String(logoUrl),
+            alt_text: `${biz.name} logo`,
+            is_primary: false,
+            sort_order: 100,
+          })
+        }
+      }
 
       if (imageRows.length > 0) {
         const { error: imgError } = await supabase
@@ -328,10 +430,12 @@ async function importRealData(excelFilePath: string) {
         if (imgError) {
           console.warn('⚠️  Error inserting images:', imgError.message)
         } else {
-          console.log(`✅ Inserted ${imageRows.length} primary photos`)
+          const primaryCount = imageRows.filter(r => r.is_primary).length
+          const logoCount    = imageRows.filter(r => !r.is_primary && r.sort_order === 100).length
+          console.log(`✅ Inserted ${primaryCount} primary photos and ${logoCount} logos`)
         }
       } else {
-        console.log('ℹ️  No photo URLs found in CSV')
+        console.log('ℹ️  No photo or logo URLs found in CSV')
       }
     }
 

--- a/src/lib/seed/scrape-services.ts
+++ b/src/lib/seed/scrape-services.ts
@@ -43,15 +43,15 @@ async function scrapePage(url: string, browser: Browser): Promise<ScrapedData> {
 
       // Strategy 1: elements whose class or id contains "service"
       document.querySelectorAll('[class*="service"], [id*="service"]').forEach(el => {
-        el.querySelectorAll('h2, h3, h4, li, [class*="title"], [class*="name"]').forEach(item => {
+        el.querySelectorAll('h1, h2, h3, h4, li, [class*="title"], [class*="name"]').forEach(item => {
           const text = item.textContent?.trim() ?? ''
           if (text.length > 2 && text.length < 80) candidates.add(text)
         })
       })
 
-      // Strategy 2: scan h2/h3 for service-related keywords (fallback)
+      // Strategy 2: scan h1/h2/h3/h4 for service-related keywords
       if (candidates.size === 0) {
-        document.querySelectorAll('h2, h3').forEach(heading => {
+        document.querySelectorAll('h1, h2, h3, h4').forEach(heading => {
           const text = heading.textContent?.trim() ?? ''
           const lower = text.toLowerCase()
           if (keywords.some(kw => lower.includes(kw)) && text.length < 80) {
@@ -60,10 +60,10 @@ async function scrapePage(url: string, browser: Browser): Promise<ScrapedData> {
         })
       }
 
-      // Strategy 3: list items inside a section/div that contains a service keyword heading
+      // Strategy 3: list items inside a section/div with a service keyword heading
       if (candidates.size === 0) {
         document.querySelectorAll('section, div').forEach(section => {
-          const heading = section.querySelector('h2, h3')
+          const heading = section.querySelector('h1, h2, h3, h4')
           if (!heading) return
           const headingText = heading.textContent?.toLowerCase() ?? ''
           if (!keywords.some(kw => headingText.includes(kw))) return
@@ -74,7 +74,51 @@ async function scrapePage(url: string, browser: Browser): Promise<ScrapedData> {
         })
       }
 
-      return [...candidates].slice(0, 15)
+      // Strategy 4: divs/spans/p elements inside sections with keyword headings
+      // Handles grid/card layouts that don't use <li>
+      if (candidates.size === 0) {
+        document.querySelectorAll('section, div').forEach(section => {
+          const heading = section.querySelector('h1, h2, h3, h4')
+          if (!heading) return
+          const headingText = heading.textContent?.toLowerCase() ?? ''
+          if (!keywords.some(kw => headingText.includes(kw))) return
+
+          // Look for direct child divs/spans/p that contain short service text
+          section.querySelectorAll('div > p, div > span, div > div, article, .card, .item, .tile').forEach(item => {
+            const text = item.textContent?.trim() ?? ''
+            // Only pick up short, leaf-level text that looks like a service name
+            if (text.length > 3 && text.length < 80 && !item.querySelector('p, h1, h2, h3, h4')) {
+              candidates.add(text)
+            }
+          })
+        })
+      }
+
+      // Strategy 5: elements with class names matching card/item/tile patterns in any section
+      if (candidates.size === 0) {
+        document.querySelectorAll(
+          '[class*="item"], [class*="card"], [class*="tile"], [class*="box"]'
+        ).forEach(el => {
+          // Only pick up elements that are inside a section/div that has a keyword heading
+          let parent = el.parentElement
+          while (parent) {
+            const heading = parent.querySelector('h1, h2, h3, h4')
+            if (heading) {
+              const headingText = heading.textContent?.toLowerCase() ?? ''
+              if (keywords.some(kw => headingText.includes(kw))) {
+                const text = el.textContent?.trim() ?? ''
+                if (text.length > 3 && text.length < 80 && !el.querySelector('p, h1, h2, h3, h4')) {
+                  candidates.add(text)
+                }
+                break
+              }
+            }
+            parent = parent.parentElement
+          }
+        })
+      }
+
+      return [...candidates].slice(0, 20)
     }, SERVICE_KEYWORDS)
 
     // --- Extract additional photos ---
@@ -94,7 +138,7 @@ async function scrapePage(url: string, browser: Browser): Promise<ScrapedData> {
           !img.src.toLowerCase().includes('favicon')
         )
         .map(img => img.src)
-        .slice(0, 2)
+        .slice(0, 5)
     })
 
     return {
@@ -112,18 +156,20 @@ async function scrapePage(url: string, browser: Browser): Promise<ScrapedData> {
 
 /**
  * Main scraper: processes all businesses in the DB that have a website
- * but no services data yet. Resumable — re-running skips already-processed rows.
+ * but no scraped services yet. Resumable — re-running skips already-processed rows.
+ * Also re-processes businesses that previously returned empty results (services = []).
  */
 async function scrapeServices() {
   const supabase = createAdminClient()
 
-  // Fetch businesses that need scraping
+  // Fetch businesses that need scraping:
+  // - services IS NULL (never scraped)
+  // - OR services has no entries with source = 'scraped' (only google-imported or empty)
   const { data: businesses, error } = await supabase
     .from('businesses')
-    .select('id, name, website, slug')
+    .select('id, name, website, slug, services')
     .eq('status', 'active')
     .not('website', 'is', null)
-    .is('services', null)
     .order('created_at', { ascending: true })
 
   if (error) {
@@ -131,12 +177,20 @@ async function scrapeServices() {
     process.exit(1)
   }
 
-  if (!businesses || businesses.length === 0) {
-    console.log('ℹ️  No businesses need scraping (all have services data or no website).')
+  // Filter to only businesses that don't already have scraped services
+  const needsScraping = (businesses ?? []).filter(biz => {
+    if (!biz.services) return true // never processed
+    const services = biz.services as Array<{ name: string; source: string }>
+    if (!Array.isArray(services) || services.length === 0) return true // empty result, retry
+    return !services.some(s => s.source === 'scraped') // has services but none scraped yet
+  })
+
+  if (needsScraping.length === 0) {
+    console.log('ℹ️  No businesses need scraping (all have scraped services data or no website).')
     return
   }
 
-  console.log(`🔍 Scraping ${businesses.length} businesses...\n`)
+  console.log(`🔍 Scraping ${needsScraping.length} businesses...\n`)
 
   const browser = await chromium.launch({ headless: true })
 
@@ -144,21 +198,28 @@ async function scrapeServices() {
     let successCount = 0
     let failCount    = 0
 
-    for (let i = 0; i < businesses.length; i += BATCH_SIZE) {
-      const batch = businesses.slice(i, i + BATCH_SIZE)
+    for (let i = 0; i < needsScraping.length; i += BATCH_SIZE) {
+      const batch = needsScraping.slice(i, i + BATCH_SIZE)
 
       await Promise.allSettled(
         batch.map(async (biz, batchIdx) => {
           const globalIdx = i + batchIdx + 1
           const url = biz.website!.startsWith('http') ? biz.website! : `https://${biz.website}`
-          console.log(`  [${globalIdx}/${businesses.length}] ${biz.name}`)
+          console.log(`  [${globalIdx}/${needsScraping.length}] ${biz.name}`)
 
           const scraped = await scrapePage(url, browser)
 
-          // Always update — even empty array marks the row as processed
+          // Merge scraped services with existing (non-scraped) services, deduplicating by name
+          const existingServices = Array.isArray(biz.services)
+            ? (biz.services as Array<{ name: string; source: string }>).filter(s => s.source !== 'scraped')
+            : []
+          const existingNames = new Set(existingServices.map(s => s.name.toLowerCase()))
+          const newScraped = scraped.services.filter(s => !existingNames.has(s.name.toLowerCase()))
+          const mergedServices = [...existingServices, ...newScraped]
+
           const { error: updateErr } = await supabase
             .from('businesses')
-            .update({ services: scraped.services })
+            .update({ services: mergedServices })
             .eq('id', biz.id)
 
           if (updateErr) {
@@ -166,26 +227,26 @@ async function scrapeServices() {
             failCount++
           } else {
             if (scraped.services.length > 0) {
-              console.log(`    ✅ ${scraped.services.length} services found`)
+              console.log(`    ✅ ${scraped.services.length} scraped services found (${existingServices.length} existing preserved)`)
               successCount++
             } else {
-              console.log(`    ○  No services found`)
+              console.log(`    ○  No scraped services found`)
               failCount++
             }
           }
 
-          // Insert extra photos
+          // Insert extra photos (skip duplicates by checking existing images)
           if (scraped.extra_photos.length > 0) {
-            const imageRows = scraped.extra_photos.map((url, idx) => ({
+            const imageRows = scraped.extra_photos.map((photoUrl, idx) => ({
               business_id: biz.id,
-              url,
+              url: photoUrl,
               alt_text: `${biz.name} photo ${idx + 2}`,
               is_primary: false,
               sort_order: idx + 1,
             }))
             const { error: imgErr } = await supabase
               .from('business_images')
-              .insert(imageRows)
+              .upsert(imageRows, { onConflict: 'business_id,url', ignoreDuplicates: true })
             if (imgErr) {
               console.warn(`    ⚠️  Image insert failed: ${imgErr.message}`)
             } else {
@@ -196,17 +257,14 @@ async function scrapeServices() {
       )
 
       // Pause between batches to be polite to servers
-      if (i + BATCH_SIZE < businesses.length) {
+      if (i + BATCH_SIZE < needsScraping.length) {
         await new Promise(r => setTimeout(r, BATCH_PAUSE_MS))
       }
     }
 
     console.log(`\n🎉 Scraping complete!`)
-    console.log(`   Services found: ${successCount} / ${businesses.length}`)
-    console.log(`   No data found:  ${failCount} / ${businesses.length}`)
-    console.log(`\n💡 To re-scrape failed businesses, run:`)
-    console.log(`   UPDATE businesses SET services = NULL WHERE services = '[]'::jsonb;`)
-    console.log(`   Then run npm run scrape-services again.`)
+    console.log(`   Services found: ${successCount} / ${needsScraping.length}`)
+    console.log(`   No data found:  ${failCount} / ${needsScraping.length}`)
   } finally {
     await browser.close()
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export interface BusinessHours {
 export interface ServiceItem {
   name: string;
   description?: string;
-  source?: 'csv' | 'scraped' | 'manual';
+  source?: 'csv' | 'scraped' | 'manual' | 'google';
 }
 
 export interface SocialMedia {
@@ -51,6 +51,7 @@ export interface Business {
   working_hours?: BusinessHours | null;
   services?: ServiceItem[] | null;
   social_media?: SocialMedia | null;
+  attributes?: Record<string, Record<string, boolean>> | null;
 }
 
 export interface BusinessImage {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS business_images (
 );
 
 CREATE INDEX IF NOT EXISTS idx_business_images_business_id ON business_images (business_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_business_images_business_url ON business_images (business_id, url);
 
 -- ============================================================
 -- reviews table
@@ -159,10 +160,11 @@ CREATE POLICY "Public can insert reviews"
 -- (service role bypasses RLS by default in Supabase)
 
 -- ============================================================
--- Phase 2 additions: hours, booking, services, social media
+-- Phase 2 additions: hours, booking, services, social media, attributes
 -- ============================================================
 ALTER TABLE businesses
   ADD COLUMN IF NOT EXISTS booking_url    TEXT,
   ADD COLUMN IF NOT EXISTS working_hours  JSONB,
   ADD COLUMN IF NOT EXISTS services       JSONB,
-  ADD COLUMN IF NOT EXISTS social_media   JSONB;
+  ADD COLUMN IF NOT EXISTS social_media   JSONB,
+  ADD COLUMN IF NOT EXISTS attributes     JSONB;


### PR DESCRIPTION
Fixes #14

- Parse `about` JSON to extract services (source: google) and structured attributes (Accessibility, Amenities, etc.)
- Use `website_description` as plain-text description instead of raw JSON
- Parse `subtypes` as fallback services; import `logo` images
- Improved scraper with 5 strategies, merging scraped + existing services, re-processing empty results
- New `attributes` JSONB column in schema
- Updated types and ListingDetail display

Generated with [Claude Code](https://claude.ai/code)