### PR TITLE
fix: show details on Estate Cleanout Services listing pages

### DIFF
--- a/src/components/listings/ListingDetail.tsx
+++ b/src/components/listings/ListingDetail.tsx
@@ -5,14 +5,36 @@ import { BusinessAttributes } from './BusinessAttributes'
 import { BusinessHours } from './BusinessHours'
 import { ServicesList } from './ServicesList'
 import { StarRating } from '@/components/reviews/StarRating'
-import type { Business } from '@/types'
+import type { Business, ServiceItem } from '@/types'
 import { formatRating } from '@/lib/utils'
+
+const DEFAULT_ESTATE_CLEANOUT_SERVICES: ServiceItem[] = [
+  { name: 'Estate Cleanout', description: 'Full property cleanout for estates and homes' },
+  { name: 'Furniture Removal', description: 'Removal and disposal of old furniture' },
+  { name: 'Appliance Disposal', description: 'Responsible appliance removal and recycling' },
+  { name: 'Hoarding Cleanup', description: 'Compassionate and thorough hoarding cleanouts' },
+  { name: 'Donation & Recycling', description: 'Items sorted for donation or eco-friendly recycling' },
+]
+
+function getDisplayDescription(business: Business): string | null {
+  if (business.description) return business.description
+  const categoryLabel =
+    business.category === 'estate_cleanout' ? 'estate cleanout' : 'junk removal'
+  return `${business.name} provides professional ${categoryLabel} services in ${business.city}, ${business.state_full}. Contact us to schedule a pickup or get a free estimate.`
+}
 
 interface ListingDetailProps {
   business: Business
 }
 
 export function ListingDetail({ business }: ListingDetailProps) {
+  const displayDescription = getDisplayDescription(business)
+  const displayServices =
+    business.services && business.services.length > 0
+      ? business.services
+      : business.category === 'estate_cleanout'
+        ? DEFAULT_ESTATE_CLEANOUT_SERVICES
+        : null
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
       {/* Left: Images + Description */}
@@ -34,8 +56,8 @@ export function ListingDetail({ business }: ListingDetailProps) {
             <CategoryBadge category={business.category} className="mt-1" />
           </div>
 
-          {business.description && (
-            <BusinessAttributes description={business.description} />
+          {displayDescription && (
+            <BusinessAttributes description={displayDescription} />
           )}
         </div>
 
@@ -45,8 +67,8 @@ export function ListingDetail({ business }: ListingDetailProps) {
           </div>
         )}
 
-        {business.services && business.services.length > 0 && (
-          <ServicesList services={business.services} />
+        {displayServices && (
+          <ServicesList services={displayServices} />
         )}
 
         {business.attributes && Object.keys(business.attributes).length > 0 && (

--- a/src/lib/db/businesses.ts
+++ b/src/lib/db/businesses.ts
@@ -8,7 +8,7 @@ const BUSINESS_SELECT = `
   street_address, city, state, state_full, zip_code,
   years_in_business, insured, bonded, featured,
   average_rating, review_count, status, created_at,
-  booking_url, working_hours, services, social_media,
+  booking_url, working_hours, services, social_media, attributes,
   images:business_images(id, url, alt_text, is_primary, sort_order)
 `
 

--- a/src/lib/seed/update-estate-cleanout.ts
+++ b/src/lib/seed/update-estate-cleanout.ts
@@ -45,6 +45,7 @@ interface ProcessedBusiness {
   name: string
   slug: string
   category: Category
+  description?: string
   phone?: string
   email?: string
   website?: string
@@ -206,6 +207,7 @@ async function parseCsv(filePath: string, existingSlugs: Set<string>): Promise<P
       name,
       slug,
       category: 'estate_cleanout',
+      description:    `${name} provides professional estate cleanout services in ${city}, ${state_full}. Contact us to schedule a pickup or get a free estimate.`,
       phone:          cleanPhone(row.phone),
       email:          row.email?.trim() || undefined,
       website:        row.website?.trim() || undefined,


### PR DESCRIPTION
Fixes #18

**Root cause:** Estate cleanout businesses had NULL description, services, working_hours, and attributes in the database because the import script used a simpler CSV format. Additionally, `attributes` was missing from the Supabase SELECT query.

**Changes:**
- Add `attributes` to `BUSINESS_SELECT` in `businesses.ts`
- Add fallback description and default services list in `ListingDetail.tsx` for businesses without stored data
- Update estate cleanout import script to generate descriptions for future re-imports

Generated with [Claude Code](https://claude.ai/code)