### PR TITLE
fix: improve city/state search and add type-ahead autocomplete

### DIFF
--- a/src/app/api/cities/route.ts
+++ b/src/app/api/cities/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCitySuggestions } from '@/lib/db/businesses'
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get('q') ?? ''
+  if (q.trim().length < 2) {
+    return NextResponse.json([])
+  }
+
+  try {
+    const suggestions = await getCitySuggestions(q)
+    return NextResponse.json(suggestions)
+  } catch {
+    return NextResponse.json([], { status: 500 })
+  }
+}

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -15,6 +15,11 @@ interface SearchBarProps {
   currentState?: string
 }
 
+interface CitySuggestion {
+  city: string
+  state: string
+}
+
 export function SearchBar({
   initialQuery = '',
   placeholder = 'Search by city, state, or zip code...',
@@ -24,11 +29,47 @@ export function SearchBar({
 }: SearchBarProps) {
   const router = useRouter()
   const [query, setQuery] = useState(initialQuery)
+  const [suggestions, setSuggestions] = useState<CitySuggestion[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [activeSuggestion, setActiveSuggestion] = useState(-1)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const fetchSuggestions = useCallback(async (val: string) => {
+    if (val.trim().length < 2) {
+      setSuggestions([])
+      setShowSuggestions(false)
+      return
+    }
+    try {
+      const res = await fetch(`/api/cities?q=${encodeURIComponent(val)}`)
+      if (res.ok) {
+        const data: CitySuggestion[] = await res.json()
+        setSuggestions(data)
+        setShowSuggestions(data.length > 0)
+      }
+    } catch {
+      setSuggestions([])
+    }
+  }, [])
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowSuggestions(false)
+        setActiveSuggestion(-1)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    setShowSuggestions(false)
+    setActiveSuggestion(-1)
     const url = buildSearchUrl({
       q: query,
       ...(currentCategory && { category: currentCategory }),
@@ -40,22 +81,81 @@ export function SearchBar({
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const val = e.target.value
     setQuery(val)
+    setActiveSuggestion(-1)
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
-      // Debounce: only push on explicit submit, not on every keystroke
-    }, 300)
+      fetchSuggestions(val)
+    }, 250)
+  }
+
+  function handleSelectSuggestion(suggestion: CitySuggestion) {
+    const value = `${suggestion.city}, ${suggestion.state}`
+    setQuery(value)
+    setShowSuggestions(false)
+    setActiveSuggestion(-1)
+    const url = buildSearchUrl({
+      q: value,
+      ...(currentCategory && { category: currentCategory }),
+      ...(currentState && { state: currentState }),
+    })
+    router.push(url)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!showSuggestions || suggestions.length === 0) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveSuggestion((prev) => Math.min(prev + 1, suggestions.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveSuggestion((prev) => Math.max(prev - 1, -1))
+    } else if (e.key === 'Enter' && activeSuggestion >= 0) {
+      e.preventDefault()
+      handleSelectSuggestion(suggestions[activeSuggestion])
+    } else if (e.key === 'Escape') {
+      setShowSuggestions(false)
+      setActiveSuggestion(-1)
+    }
   }
 
   return (
     <form onSubmit={handleSubmit} className="flex gap-2 w-full">
-      <div className="relative flex-1">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+      <div className="relative flex-1" ref={containerRef}>
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none z-10" />
         <Input
           value={query}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            if (suggestions.length > 0) setShowSuggestions(true)
+          }}
           placeholder={placeholder}
           className={large ? 'pl-10 h-12 text-base' : 'pl-10'}
+          autoComplete="off"
         />
+        {showSuggestions && suggestions.length > 0 && (
+          <ul className="absolute z-50 left-0 right-0 top-full mt-1 bg-background border border-border rounded-md shadow-lg max-h-60 overflow-y-auto">
+            {suggestions.map((s, i) => (
+              <li
+                key={`${s.city}-${s.state}`}
+                className={`flex items-center gap-2 px-4 py-2 cursor-pointer text-sm ${
+                  i === activeSuggestion
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent hover:text-accent-foreground'
+                }`}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  handleSelectSuggestion(s)
+                }}
+              >
+                <Search className="h-3 w-3 text-muted-foreground shrink-0" />
+                <span>
+                  {s.city}, <span className="font-medium">{s.state}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
       <Button type="submit" className={large ? 'h-12 px-6' : ''}>
         Search

--- a/src/lib/db/businesses.ts
+++ b/src/lib/db/businesses.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@/lib/supabase/server'
 import type { Business, SearchParams } from '@/types'
-import { isZipCode, isStateAbbr } from '@/lib/utils'
+import { isZipCode, isStateAbbr, isCityState, parseCityState } from '@/lib/utils'
 import { PAGE_SIZE } from '@/lib/constants'
 
 const BUSINESS_SELECT = `
@@ -31,6 +31,9 @@ export async function searchBusinesses(params: SearchParams): Promise<{
       query = query.eq('zip_code', trimmed)
     } else if (isStateAbbr(trimmed)) {
       query = query.eq('state', trimmed)
+    } else if (isCityState(trimmed)) {
+      const { city, state: stateAbbr } = parseCityState(trimmed)
+      query = query.ilike('city', `%${city}%`).eq('state', stateAbbr)
     } else {
       query = query.textSearch('search_vector', trimmed, {
         type: 'plain',
@@ -94,6 +97,35 @@ export async function getFeaturedBusinesses(): Promise<Business[]> {
 
   if (error) throw error
   return (data as Business[]) ?? []
+}
+
+export async function getCitySuggestions(q: string, limit = 8): Promise<{ city: string; state: string }[]> {
+  const supabase = await createClient()
+  const trimmed = q.trim()
+  if (!trimmed) return []
+
+  const { data, error } = await supabase
+    .from('businesses')
+    .select('city, state')
+    .eq('status', 'active')
+    .ilike('city', `%${trimmed}%`)
+    .order('city', { ascending: true })
+    .limit(limit * 4) // over-fetch to deduplicate in JS
+
+  if (error) return []
+
+  // Deduplicate city+state combinations
+  const seen = new Set<string>()
+  const results: { city: string; state: string }[] = []
+  for (const row of (data ?? [])) {
+    const key = `${row.city},${row.state}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      results.push({ city: row.city, state: row.state })
+      if (results.length >= limit) break
+    }
+  }
+  return results
 }
 
 export async function getBusinessesByCategory(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,6 +28,16 @@ export function isStateAbbr(query: string): boolean {
   return /^[A-Z]{2}$/.test(query.trim())
 }
 
+export function isCityState(query: string): boolean {
+  return /^.+,\s*[A-Za-z]{2}$/.test(query.trim())
+}
+
+export function parseCityState(query: string): { city: string; state: string } {
+  const match = query.trim().match(/^(.+),\s*([A-Za-z]{2})$/)
+  if (!match) return { city: query.trim(), state: '' }
+  return { city: match[1].trim(), state: match[2].toUpperCase() }
+}
+
 export function formatCityState(city: string, state: string): string {
   return `${city}, ${state}`
 }


### PR DESCRIPTION
Fixes #22

**Changes:**
- Parse "City, State" queries using ilike + eq instead of full-text search
- Add isCityState() and parseCityState() helpers
- Add getCitySuggestions() + /api/cities endpoint
- SearchBar type-ahead dropdown with keyboard navigation

Generated with [Claude Code](https://claude.ai/code)