### PR TITLE
fix: remove overflow-hidden that clipped search dropdown

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -161,7 +161,7 @@ function EstateCleanoutCard() {
 
 export function HeroSection() {
   return (
-    <section className="relative overflow-hidden" style={{ minHeight: 520 }}>
+    <section className="relative" style={{ minHeight: 520 }}>
       {/* Full-width panoramic background photo */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
@@ -254,7 +254,7 @@ export function HeroSection() {
                   boxShadow: '0 4px 24px rgba(37,99,235,0.2)',
                 }}
               >
-                <div style={{ borderRadius: 11, overflow: 'hidden', background: 'white' }}>
+                <div style={{ borderRadius: 11, background: 'white' }}>
                   <SearchBar placeholder="Enter city, state, or zip code..." large />
                 </div>
               </div>


### PR DESCRIPTION
Fixes #22

The hero section redesign introduced two `overflow: hidden` rules that clipped the absolutely-positioned type-ahead dropdown in SearchBar. Removed both since neither is needed for the visual design.

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/achatter/haulandremove/tree/claude/issue-22-20260412-1759) | [View job run](https://github.com/achatter/haulandremove/actions/runs/24312858223