### PR TITLE
fix: wrap SearchFilters in Suspense to restore dropdown filtering

### DIFF
--- a/src/components/search/SearchFilters.tsx
+++ b/src/components/search/SearchFilters.tsx
@@ -26,7 +26,7 @@ export function SearchFilters() {
     } else {
       sp.delete(key)
     }
-    router.push(`${pathname}?${sp.toString()}`)
+    router.push(`${pathname}?${sp.toString()}`, { scroll: false })
   }
 
   return (

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { ListingGrid } from '@/components/listings/ListingGrid'
 import { SearchFilters } from './SearchFilters'
 import type { Business, SearchParams } from '@/types'
@@ -22,7 +23,9 @@ export function SearchResults({ businesses, count, params }: SearchResultsProps)
             <span> for &ldquo;<strong className="text-foreground">{params.q}</strong>&rdquo;</span>
           )}
         </p>
-        <SearchFilters />
+        <Suspense fallback={null}>
+          <SearchFilters />
+        </Suspense>
       </div>
 
       <ListingGrid businesses={businesses} />


### PR DESCRIPTION
Fixes #20

## Problem

The `SearchFilters` component uses `useSearchParams()` but was not wrapped in a `<Suspense>` boundary. In Next.js 15/16, `useSearchParams()` requires a Suspense boundary — without one, the hook may return stale or empty params during SSR/hydration. This caused `updateParams()` to build new URLs from an empty `URLSearchParams`, silently dropping the current `q` (search query) and other active filters.

## Changes

- `SearchResults.tsx`: Wrap `<SearchFilters />` in `<Suspense fallback={null}>`
- `SearchFilters.tsx`: Add `{ scroll: false }` to `router.push` so filter changes don't scroll the page to top

Generated with [Claude Code](https://claude.ai/code)