### PR TITLE
fix: add image error handling and fix seed data bugs

### DIFF
--- a/src/components/listings/ImageGallery.tsx
+++ b/src/components/listings/ImageGallery.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import Image from 'next/image'
 import type { BusinessImage } from '@/types'
 
@@ -9,30 +10,46 @@ interface ImageGalleryProps {
 }
 
 export function ImageGallery({ images, businessName }: ImageGalleryProps) {
+  const [errorIds, setErrorIds] = useState<Set<string>>(new Set())
+
   if (images.length === 0) return null
 
   const sorted = [...images].sort((a, b) => a.sort_order - b.sort_order)
   const primary = sorted.find((img) => img.is_primary) ?? sorted[0]
   const rest = sorted.filter((img) => img.id !== primary.id)
 
+  const handleError = (id: string) => {
+    setErrorIds((prev) => new Set([...prev, id]))
+  }
+
+  const primaryFailed = errorIds.has(primary.id)
+  const visibleThumbnails = rest.filter((img) => !errorIds.has(img.id))
+
   return (
     <div className="space-y-3">
       {/* Primary image */}
       <div className="relative aspect-video rounded-xl overflow-hidden bg-muted">
-        <Image
-          src={primary.url}
-          alt={primary.alt_text || businessName}
-          fill
-          className="object-cover"
-          priority
-          sizes="(max-width: 768px) 100vw, 800px"
-        />
+        {primaryFailed ? (
+          <div className="absolute inset-0 flex items-center justify-center bg-muted">
+            <span className="text-muted-foreground text-sm">Image unavailable</span>
+          </div>
+        ) : (
+          <Image
+            src={primary.url}
+            alt={primary.alt_text || businessName}
+            fill
+            className="object-cover"
+            priority
+            sizes="(max-width: 768px) 100vw, 800px"
+            onError={() => handleError(primary.id)}
+          />
+        )}
       </div>
 
       {/* Thumbnail strip */}
-      {rest.length > 0 && (
+      {visibleThumbnails.length > 0 && (
         <div className="flex gap-2 overflow-x-auto pb-1">
-          {rest.map((img) => (
+          {visibleThumbnails.map((img) => (
             <div
               key={img.id}
               className="relative shrink-0 w-24 h-16 rounded-lg overflow-hidden bg-muted"
@@ -43,6 +60,7 @@ export function ImageGallery({ images, businessName }: ImageGalleryProps) {
                 fill
                 className="object-cover"
                 sizes="96px"
+                onError={() => handleError(img.id)}
               />
             </div>
           ))}

--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link'
-import Image from 'next/image'
-import { MapPin, Phone, Shield, ArrowUpRight } from 'lucide-react'
+import { MapPin, Phone, ArrowUpRight } from 'lucide-react'
 import { StarRating } from '@/components/reviews/StarRating'
 import type { Business } from '@/types'
 import { formatPhone, formatRating } from '@/lib/utils'
+import { ListingCardImage } from './ListingCardImage'
 
 // Bold McKinsey-style tile palette
 const tilePalette = [
@@ -43,16 +43,7 @@ export function ListingCard({ business }: ListingCardProps) {
         {/* ── Image / Color Tile ── */}
         <div className="relative overflow-hidden" style={{ height: 220 }}>
           {primaryImage ? (
-            <>
-              <Image
-                src={primaryImage.url}
-                alt={primaryImage.alt_text}
-                fill
-                className="object-cover group-hover:scale-105 transition-transform duration-700"
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-black/10 to-transparent" />
-            </>
+            <ListingCardImage image={primaryImage} tileBg={tile.bg} tileAccent={tile.accent} businessName={business.name} />
           ) : (
             <div className="absolute inset-0" style={{ backgroundColor: tile.bg }}>
               {/* Diagonal line pattern */}

--- a/src/components/listings/ListingCardImage.tsx
+++ b/src/components/listings/ListingCardImage.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import type { BusinessImage } from '@/types'
+
+interface ListingCardImageProps {
+  image: BusinessImage
+  tileBg: string
+  tileAccent: string
+  businessName: string
+}
+
+export function ListingCardImage({ image, tileBg, tileAccent, businessName }: ListingCardImageProps) {
+  const [hasError, setHasError] = useState(false)
+
+  if (hasError) {
+    return (
+      <div className="absolute inset-0" style={{ backgroundColor: tileBg }}>
+        <div
+          className="absolute inset-0 opacity-[0.07]"
+          style={{
+            backgroundImage: `repeating-linear-gradient(
+              -45deg,
+              rgba(255,255,255,0.8) 0px,
+              rgba(255,255,255,0.8) 1px,
+              transparent 1px,
+              transparent 18px
+            )`,
+          }}
+        />
+        <div
+          className="absolute -top-12 -right-12 w-48 h-48 rounded-full opacity-10"
+          style={{ backgroundColor: tileAccent }}
+        />
+        <div
+          className="absolute -bottom-8 -left-8 w-32 h-32 rounded-full opacity-10"
+          style={{ backgroundColor: tileAccent }}
+        />
+        <div className="absolute inset-0 flex flex-col justify-end p-6">
+          <p className="text-white font-serif font-bold text-xl leading-tight line-clamp-3">
+            {businessName}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Image
+        src={image.url}
+        alt={image.alt_text}
+        fill
+        className="object-cover group-hover:scale-105 transition-transform duration-700"
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        onError={() => setHasError(true)}
+      />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-black/10 to-transparent" />
+    </>
+  )
+}

--- a/src/lib/seed/data.ts
+++ b/src/lib/seed/data.ts
@@ -32,7 +32,7 @@ interface SeedReview {
 const PHOTOS = {
   junk: [
     { id: '1558618666-fcd25c85cd64', alt: 'Junk removal truck loaded with debris' },
-    { id: '1558618666-fcd25c85cd64', alt: 'Crew removing furniture from home' },
+    { id: '1530126174756-aeefa3b5c4ef', alt: 'Crew removing furniture from home' },
     { id: '1504307651254-35680f356dfd', alt: 'Dumpster bin for waste removal' },
     { id: '1581578731548-c64695cc6952', alt: 'Team clearing out garage clutter' },
     { id: '1530124566582-a618bc2615dc', alt: 'Junk removal professionals at work' },
@@ -52,26 +52,22 @@ const PHOTOS = {
   ],
 }
 
+function pickPhotos(pool: typeof PHOTOS.junk, start: number, count: number) {
+  const len = pool.length
+  return Array.from({ length: count }, (_, i) => pool[(start + i) % len]).map((p, i) => ({
+    url: `https://images.unsplash.com/photo-${p.id}?w=800&q=80`,
+    alt_text: p.alt,
+    is_primary: i === 0,
+    sort_order: i,
+  }))
+}
+
 function junkPhotos(start = 0, count = 3) {
-  return PHOTOS.junk.slice(start % PHOTOS.junk.length, (start % PHOTOS.junk.length) + count).map(
-    (p, i) => ({
-      url: `https://images.unsplash.com/photo-${p.id}?w=800&q=80`,
-      alt_text: p.alt,
-      is_primary: i === 0,
-      sort_order: i,
-    })
-  )
+  return pickPhotos(PHOTOS.junk, start, count)
 }
 
 function estatePhotos(start = 0, count = 3) {
-  return PHOTOS.estate.slice(start % PHOTOS.estate.length, (start % PHOTOS.estate.length) + count).map(
-    (p, i) => ({
-      url: `https://images.unsplash.com/photo-${p.id}?w=800&q=80`,
-      alt_text: p.alt,
-      is_primary: i === 0,
-      sort_order: i,
-    })
-  )
+  return pickPhotos(PHOTOS.estate, start, count)
 }
 
 export const SEED_BUSINESSES: SeedBusiness[] = [


### PR DESCRIPTION
Fixes #issue-35

- Add ListingCardImage client component that falls back to the color tile when an Unsplash URL fails to load
- Add onError + Set tracking in ImageGallery so broken images are hidden rather than shown as broken icons
- Fix duplicate photo ID at PHOTOS.junk[1] in seed data
- Fix slice boundary overflow in junkPhotos/estatePhotos helpers

Generated with [Claude Code](https://claude.ai/code)