### PR TITLE
fix: SEO city pages returning zero results due to state slug mismatch

### DIFF
--- a/src/app/[category]/[state]/[city]/page.tsx
+++ b/src/app/[category]/[state]/[city]/page.tsx
@@ -5,14 +5,14 @@ import { SearchBar } from '@/components/search/SearchBar'
 import { SearchResults } from '@/components/search/SearchResults'
 import { getBusinessesByCategoryAndCity } from '@/lib/db/businesses'
 import { CATEGORIES, CITIES_BY_STATE } from '@/lib/constants'
-import { toSlug, fromSlug, categorySlugToKey } from '@/lib/utils'
+import { toSlug, fromSlug, categorySlugToKey, stateSlugToAbbr, stateAbbrToSlug } from '@/lib/utils'
 
 interface PageProps {
   params: Promise<{ category: string; state: string; city: string }>
 }
 
 function resolveCityName(stateAbbr: string, citySlug: string): string {
-  const cities = CITIES_BY_STATE[stateAbbr.toUpperCase()] ?? []
+  const cities = CITIES_BY_STATE[stateAbbr] ?? []
   const match = cities.find(c => toSlug(c) === citySlug)
   return match ?? fromSlug(citySlug)
 }
@@ -24,7 +24,7 @@ export async function generateStaticParams() {
       for (const city of cities) {
         params.push({
           category: categorySlug,
-          state: stateAbbr.toLowerCase(),
+          state: stateAbbrToSlug(stateAbbr), // e.g. "california" not "ca"
           city: toSlug(city),
         })
       }
@@ -34,34 +34,38 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { category: categorySlug, state, city: citySlug } = await params
+  const { category: categorySlug, state: stateSlug, city: citySlug } = await params
   const categoryKey = categorySlugToKey(categorySlug)
   if (!categoryKey) return {}
 
+  const stateAbbr = stateSlugToAbbr(stateSlug)
+  if (!stateAbbr) return {}
+
   const categoryLabel = CATEGORIES[categoryKey].label
-  const cityName = resolveCityName(state, citySlug)
-  const stateUpper = state.toUpperCase()
+  const cityName = resolveCityName(stateAbbr, citySlug)
 
   return {
-    title: `${categoryLabel} in ${cityName}, ${stateUpper}`,
-    description: `Find trusted ${categoryLabel.toLowerCase()} professionals in ${cityName}, ${stateUpper}. Browse ratings, reviews, and contact information for local providers.`,
+    title: `${categoryLabel} in ${cityName}, ${stateAbbr}`,
+    description: `Find trusted ${categoryLabel.toLowerCase()} professionals in ${cityName}, ${stateAbbr}. Browse ratings, reviews, and contact information for local providers.`,
   }
 }
 
 export default async function CityPage({ params }: PageProps) {
-  const { category: categorySlug, state, city: citySlug } = await params
+  const { category: categorySlug, state: stateSlug, city: citySlug } = await params
   const categoryKey = categorySlugToKey(categorySlug)
   if (!categoryKey) notFound()
 
-  const categoryLabel = CATEGORIES[categoryKey].label
-  const cityName = resolveCityName(state, citySlug)
-  const stateUpper = state.toUpperCase()
+  const stateAbbr = stateSlugToAbbr(stateSlug)
+  if (!stateAbbr) notFound()
 
-  const businesses = await getBusinessesByCategoryAndCity(categoryKey, stateUpper, cityName)
+  const categoryLabel = CATEGORIES[categoryKey].label
+  const cityName = resolveCityName(stateAbbr, citySlug)
+
+  const businesses = await getBusinessesByCategoryAndCity(categoryKey, stateAbbr, cityName)
 
   const searchParams = {
     category: categoryKey,
-    state: stateUpper,
+    state: stateAbbr,
     city: cityName,
     sort: 'rating' as const,
     page: '1',
@@ -71,10 +75,10 @@ export default async function CityPage({ params }: PageProps) {
     <Container className="py-10">
       <div className="mb-8">
         <h1 className="text-3xl font-bold tracking-tight mb-1">
-          {categoryLabel} in {cityName}, {stateUpper}
+          {categoryLabel} in {cityName}, {stateAbbr}
         </h1>
         <p className="text-muted-foreground mb-4">
-          Find trusted {categoryLabel.toLowerCase()} professionals in {cityName}, {stateUpper}.
+          Find trusted {categoryLabel.toLowerCase()} professionals in {cityName}, {stateAbbr}.
         </p>
         <SearchBar currentCategory={categoryKey} />
       </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { getDistinctCitiesForSitemap } from '@/lib/db/businesses'
 import { CATEGORIES } from '@/lib/constants'
-import { toSlug } from '@/lib/utils'
+import { toSlug, stateAbbrToSlug } from '@/lib/utils'
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://haulandremove.com'
 
@@ -27,7 +27,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       )?.slug ?? category.replace(/_/g, '-')
 
       return {
-        url: `${BASE_URL}/${categorySlug}/${state.toLowerCase()}/${toSlug(city)}`,
+        url: `${BASE_URL}/${categorySlug}/${stateAbbrToSlug(state)}/${toSlug(city)}`,
         lastModified: new Date(),
         changeFrequency: 'monthly' as const,
         priority: 0.7,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatPhone, formatRating, isZipCode, isStateAbbr, formatCityState, buildSearchUrl, toSlug, fromSlug, categorySlugToKey } from './utils'
+import { formatPhone, formatRating, isZipCode, isStateAbbr, formatCityState, buildSearchUrl, toSlug, fromSlug, categorySlugToKey, stateAbbrToSlug, stateSlugToAbbr } from './utils'
 
 describe('formatPhone', () => {
   it('formats a 10-digit number', () => {
@@ -111,5 +111,35 @@ describe('categorySlugToKey', () => {
   })
   it('returns null for unknown slugs', () => {
     expect(categorySlugToKey('other-service')).toBeNull()
+  })
+})
+
+describe('stateAbbrToSlug', () => {
+  it('converts CA to california', () => {
+    expect(stateAbbrToSlug('CA')).toBe('california')
+  })
+  it('converts TX to texas', () => {
+    expect(stateAbbrToSlug('TX')).toBe('texas')
+  })
+  it('handles lowercase abbreviation', () => {
+    expect(stateAbbrToSlug('ny')).toBe('new-york')
+  })
+  it('falls back to lowercase abbr for unknown state', () => {
+    expect(stateAbbrToSlug('ZZ')).toBe('zz')
+  })
+})
+
+describe('stateSlugToAbbr', () => {
+  it('converts california to CA', () => {
+    expect(stateSlugToAbbr('california')).toBe('CA')
+  })
+  it('converts texas to TX', () => {
+    expect(stateSlugToAbbr('texas')).toBe('TX')
+  })
+  it('converts new-york to NY', () => {
+    expect(stateSlugToAbbr('new-york')).toBe('NY')
+  })
+  it('returns null for unknown slug', () => {
+    expect(stateSlugToAbbr('unknown-state')).toBeNull()
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { US_STATES } from '@/lib/constants'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -71,5 +72,17 @@ export function categorySlugToKey(slug: string): 'junk_removal' | 'estate_cleano
   if (slug === 'junk-removal') return 'junk_removal'
   if (slug === 'estate-cleanout') return 'estate_cleanout'
   return null
+}
+
+// Converts a state abbreviation to a URL slug: "CA" → "california", "TX" → "texas"
+export function stateAbbrToSlug(abbr: string): string {
+  const found = US_STATES.find(s => s.abbr === abbr.toUpperCase())
+  return found ? toSlug(found.name) : abbr.toLowerCase()
+}
+
+// Converts a state URL slug back to abbreviation: "california" → "CA", "texas" → "TX"
+export function stateSlugToAbbr(slug: string): string | null {
+  const found = US_STATES.find(s => toSlug(s.name) === slug)
+  return found?.abbr ?? null
 }
 


### PR DESCRIPTION
Fixes #37 — city page URLs like `/junk-removal/california/san-francisco` returning zero results.

**Root cause:** The state URL segment ("california") was passed directly to the DB as "CALIFORNIA" instead of being converted to the abbreviation "CA" that the DB stores. Additionally, `generateStaticParams` was building URLs with abbreviations ("ca") rather than full names ("california").

**Changes:**
- Added `stateAbbrToSlug` and `stateSlugToAbbr` helpers to `src/lib/utils.ts`
- Updated city page to convert state slug → abbreviation before querying the DB
- Updated `generateStaticParams` to emit full state name slugs
- Updated sitemap to use full state name slugs in URLs
- 8 new tests for the new helpers

Generated with [Claude Code](https://claude.ai/code)