### PR TITLE
fix: show fallback services on city page when category has no results

### DIFF
--- a/src/app/[category]/[state]/[city]/page.tsx
+++ b/src/app/[category]/[state]/[city]/page.tsx
@@ -61,7 +61,7 @@ export default async function CityPage({ params }: PageProps) {
   const categoryLabel = CATEGORIES[categoryKey].label
   const cityName = resolveCityName(stateAbbr, citySlug)
 
-  const businesses = await getBusinessesByCategoryAndCity(categoryKey, stateAbbr, cityName)
+  const { businesses, categoryFallback } = await getBusinessesByCategoryAndCity(categoryKey, stateAbbr, cityName)
 
   const searchParams = {
     category: categoryKey,
@@ -82,7 +82,7 @@ export default async function CityPage({ params }: PageProps) {
         </p>
         <SearchBar currentCategory={categoryKey} />
       </div>
-      <SearchResults businesses={businesses} count={businesses.length} params={searchParams} />
+      <SearchResults businesses={businesses} count={businesses.length} params={searchParams} categoryFallback={categoryFallback} />
     </Container>
   )
 }

--- a/src/lib/db/businesses.ts
+++ b/src/lib/db/businesses.ts
@@ -171,20 +171,29 @@ export async function getBusinessesByCategoryAndCity(
   category: string,
   state: string,
   city: string
-): Promise<Business[]> {
+): Promise<{ businesses: Business[]; categoryFallback: boolean }> {
   const supabase = await createClient()
 
-  const { data, error } = await supabase
-    .from('businesses')
-    .select(BUSINESS_SELECT)
-    .eq('status', 'active')
-    .eq('category', category)
-    .eq('state', state.toUpperCase())
-    .ilike('city', city)
-    .order('average_rating', { ascending: false })
+  const baseQuery = () =>
+    supabase
+      .from('businesses')
+      .select(BUSINESS_SELECT)
+      .eq('status', 'active')
+      .eq('state', state.toUpperCase())
+      .ilike('city', `%${city}%`)
+      .order('average_rating', { ascending: false })
 
+  const { data, error } = await baseQuery().eq('category', category)
   if (error) throw error
-  return (data as Business[]) ?? []
+
+  if ((data ?? []).length > 0) {
+    return { businesses: data as Business[], categoryFallback: false }
+  }
+
+  // No results for requested category — fall back to all businesses in that city
+  const { data: fbData, error: fbError } = await baseQuery()
+  if (fbError) throw fbError
+  return { businesses: (fbData as Business[]) ?? [], categoryFallback: true }
 }
 
 export async function getDistinctCitiesForSitemap(): Promise<


### PR DESCRIPTION
Fixes #37 — city page URLs returning blank page when no listings for requested category.

**Root cause:** `getBusinessesByCategoryAndCity` had no fallback logic, so direct city page URLs showed a blank page when a category had no listings in that city. The search page already handled this correctly.

**Changes:**
- `getBusinessesByCategoryAndCity` now returns `{ businesses, categoryFallback }` — when 0 results for the category, falls back to all businesses in that city
- Fixed city ilike from exact match to partial match (`%city%`) for robustness
- City page now passes `categoryFallback` to `SearchResults`, which shows an explanatory banner

Closes #37

Generated with [Claude Code](https://claude.ai/code)