### PR TITLE
fix: resolve Vercel deployment error — supabaseUrl is required

### DIFF
--- a/src/app/listings/[slug]/page.tsx
+++ b/src/app/listings/[slug]/page.tsx
@@ -6,13 +6,8 @@ import { Separator } from '@/components/ui/separator'
 import { getBusinessBySlug } from '@/lib/db/businesses'
 import { getReviewsForBusiness } from '@/lib/db/reviews'
 import type { Metadata } from 'next'
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from '@/lib/supabase/server'
 import { notFound } from 'next/navigation'
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
 
 interface PageProps {
   params: Promise<{ slug: string }>
@@ -20,6 +15,7 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params
+  const supabase = await createClient()
   const { data: biz } = await supabase
     .from('businesses')
     .select('name, city, state, category, description, phone')


### PR DESCRIPTION
Fixes #41

The Supabase client in `src/app/listings/[slug]/page.tsx` was initialized at module level, which runs at build time before environment variables are available in Vercel. Moved the client creation inside `generateMetadata` and switched to the existing server utility.

Generated with [Claude Code](https://claude.ai/code)