### PR TITLE
feat: add state pages as middle layer between homepage and city pages

### DIFF
--- a/src/app/[category]/[state]/page.tsx
+++ b/src/app/[category]/[state]/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { MapPin } from 'lucide-react'
+import { Container } from '@/components/layout/Container'
+import { SearchBar } from '@/components/search/SearchBar'
+import { CATEGORIES, CITIES_BY_STATE, US_STATES } from '@/lib/constants'
+import { categorySlugToKey, stateSlugToAbbr, toSlug } from '@/lib/utils'
+
+interface PageProps {
+  params: Promise<{ category: string; state: string }>
+}
+
+export async function generateStaticParams() {
+  const params: { category: string; state: string }[] = []
+  for (const categorySlug of ['junk-removal', 'estate-cleanout']) {
+    for (const state of US_STATES) {
+      params.push({ category: categorySlug, state: toSlug(state.name) })
+    }
+  }
+  return params
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { category: categorySlug, state: stateSlug } = await params
+  const categoryKey = categorySlugToKey(categorySlug)
+  const stateAbbr = stateSlugToAbbr(stateSlug)
+  if (!categoryKey || !stateAbbr) return {}
+
+  const categoryLabel = CATEGORIES[categoryKey].label
+  const stateName = US_STATES.find(s => s.abbr === stateAbbr)?.name ?? stateAbbr
+
+  const title = `${categoryLabel} Services in ${stateName}`
+  const description = `Find trusted ${categoryLabel.toLowerCase()} companies across ${stateName}. Browse by city to find local providers, read verified reviews, and get free quotes.`
+  const url = `https://junkremovalsearch.com/${categorySlug}/${stateSlug}`
+
+  return {
+    title,
+    description,
+    openGraph: { title, description, url, type: 'website' },
+    twitter: { card: 'summary', title, description },
+    alternates: { canonical: url },
+  }
+}
+
+export default async function StatePage({ params }: PageProps) {
+  const { category: categorySlug, state: stateSlug } = await params
+  const categoryKey = categorySlugToKey(categorySlug)
+  if (!categoryKey) notFound()
+
+  const stateAbbr = stateSlugToAbbr(stateSlug)
+  if (!stateAbbr) notFound()
+
+  const stateInfo = US_STATES.find(s => s.abbr === stateAbbr)
+  if (!stateInfo) notFound()
+
+  const categoryLabel = CATEGORIES[categoryKey].label
+  const cities = CITIES_BY_STATE[stateAbbr] ?? []
+
+  return (
+    <Container className="py-10">
+      <nav className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+        <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+        <span>/</span>
+        <Link href={`/categories/${categorySlug}`} className="hover:text-foreground transition-colors">
+          {categoryLabel}
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">{stateInfo.name}</span>
+      </nav>
+
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">
+          {categoryLabel} in {stateInfo.name}
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Browse cities in {stateInfo.name} to find local {categoryLabel.toLowerCase()} professionals.
+        </p>
+        <SearchBar currentCategory={categoryKey} />
+      </div>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">
+          Cities in {stateInfo.name} ({cities.length})
+        </h2>
+
+        {cities.length === 0 ? (
+          <p className="text-muted-foreground">No cities listed for this state yet.</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {cities.map(city => (
+              <Link
+                key={city}
+                href={`/${categorySlug}/${stateSlug}/${toSlug(city)}`}
+                className="flex items-center gap-2 p-3 rounded-lg border border-slate-200 hover:border-blue-400 hover:bg-blue-50 transition-all group"
+              >
+                <MapPin className="h-4 w-4 shrink-0 text-slate-400 group-hover:text-blue-500" />
+                <span className="text-sm font-medium text-slate-700 group-hover:text-blue-600">{city}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </Container>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { HeroSection } from '@/components/home/HeroSection'
 import { FeaturedSection } from '@/components/home/FeaturedSection'
 import { CategorySection } from '@/components/home/CategorySection'
+import { StateSection } from '@/components/home/StateSection'
 import { Container } from '@/components/layout/Container'
 import { getFeaturedBusinesses } from '@/lib/db/businesses'
 import type { Metadata } from 'next'
@@ -25,6 +26,7 @@ export default async function HomePage() {
         <Container>
           <FeaturedSection businesses={featured} />
           <CategorySection />
+          <StateSection />
         </Container>
       </div>
     </>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { getDistinctCitiesForSitemap } from '@/lib/db/businesses'
-import { CATEGORIES } from '@/lib/constants'
+import { CATEGORIES, US_STATES } from '@/lib/constants'
 import { toSlug, stateAbbrToSlug } from '@/lib/utils'
 
 const BASE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? 'https://junkremovalsearch.com').trim()
@@ -10,6 +10,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: BASE_URL, lastModified: new Date(), changeFrequency: 'weekly', priority: 1.0 },
     { url: `${BASE_URL}/search`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
   ]
+
+  const statePages: MetadataRoute.Sitemap = Object.values(CATEGORIES).flatMap(cat =>
+    US_STATES.map(state => ({
+      url: `${BASE_URL}/${cat.slug}/${toSlug(state.name)}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    }))
+  )
 
   let cityPages: MetadataRoute.Sitemap = []
   try {
@@ -31,5 +40,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // If DB is unavailable during build, return only static pages
   }
 
-  return [...staticPages, ...cityPages]
+  return [...staticPages, ...statePages, ...cityPages]
 }

--- a/src/components/home/StateSection.tsx
+++ b/src/components/home/StateSection.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { MapPin } from 'lucide-react'
+import { US_STATES } from '@/lib/constants'
+import { toSlug } from '@/lib/utils'
+
+export function StateSection() {
+  return (
+    <section className="py-16">
+      <p className="text-xs font-bold uppercase tracking-widest text-blue-600 mb-3">Nationwide</p>
+      <h2 className="text-4xl font-bold text-slate-900 mb-2">Browse by State</h2>
+      <p className="text-slate-500 mb-10 text-base">Find hauling &amp; removal services in your state</p>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        {US_STATES.map(state => (
+          <Link
+            key={state.abbr}
+            href={`/junk-removal/${toSlug(state.name)}`}
+            className="flex items-center gap-2 p-3 rounded-lg border border-slate-200 hover:border-blue-400 hover:bg-blue-50 transition-all group"
+          >
+            <MapPin className="h-4 w-4 shrink-0 text-slate-400 group-hover:text-blue-500" />
+            <span className="text-sm font-medium text-slate-700 group-hover:text-blue-600">{state.name}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Implements state pages as a middle layer in the directory hierarchy: homepage → states → cities → listings.

## Changes

- Add `/[category]/[state]/page.tsx` state page with city grid and breadcrumb nav
- Add `StateSection` component showing all 50 states linked from homepage
- Update homepage to render `StateSection` below `CategorySection`
- Add state pages to sitemap at priority 0.8

Closes #44

Generated with [Claude Code](https://claude.ai/code)