### PR TITLE
fix: improve city page breadcrumb to match state page style

### DIFF
--- a/src/app/[category]/[state]/[city]/page.tsx
+++ b/src/app/[category]/[state]/[city]/page.tsx
@@ -94,10 +94,18 @@ export default async function CityPage({ params }: PageProps) {
     <Container className="py-10">
       <div className="mb-8">
         {/* Breadcrumb */}
-        <nav className="text-sm text-muted-foreground mb-3">
-          <Link href="/">Home</Link>{' '}→{' '}
-          <Link href={`/${categorySlug}/${stateSlug}`}>{stateFull}</Link>{' '}→{' '}
-          <span>{cityName}</span>
+        <nav className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+          <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+          <span>/</span>
+          <Link href={`/categories/${categorySlug}`} className="hover:text-foreground transition-colors">
+            {categoryLabel}
+          </Link>
+          <span>/</span>
+          <Link href={`/${categorySlug}/${stateSlug}`} className="hover:text-foreground transition-colors">
+            {stateFull}
+          </Link>
+          <span>/</span>
+          <span className="text-foreground">{cityName}</span>
         </nav>
         
         <h1 className="text-3xl font-bold tracking-tight mb-1">


### PR DESCRIPTION
Fixes the city page breadcrumb so it renders correctly and consistently with the state page:

- Adds the missing category step (Home / Category / State / City)
- Uses flex layout, gap-2, and / separator matching the state page
- Adds hover:text-foreground transition-colors to all breadcrumb links

Closes #46

Generated with [Claude Code](https://claude.ai/code)