### PR TITLE
fix: make breadcrumbs visually unmistakable on city and state pages

### DIFF
--- a/src/app/[category]/[state]/[city]/page.tsx
+++ b/src/app/[category]/[state]/[city]/page.tsx
@@ -94,18 +94,18 @@ export default async function CityPage({ params }: PageProps) {
     <Container className="py-10">
       <div className="mb-8">
         {/* Breadcrumb */}
-        <nav className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
-          <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
-          <span>/</span>
-          <Link href={`/categories/${categorySlug}`} className="hover:text-foreground transition-colors">
+        <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+          <Link href="/" className="hover:text-foreground transition-colors underline underline-offset-4">Home</Link>
+          <span aria-hidden="true">/</span>
+          <Link href={`/categories/${categorySlug}`} className="hover:text-foreground transition-colors underline underline-offset-4">
             {categoryLabel}
           </Link>
-          <span>/</span>
-          <Link href={`/${categorySlug}/${stateSlug}`} className="hover:text-foreground transition-colors">
+          <span aria-hidden="true">/</span>
+          <Link href={`/${categorySlug}/${stateSlug}`} className="hover:text-foreground transition-colors underline underline-offset-4">
             {stateFull}
           </Link>
-          <span>/</span>
-          <span className="text-foreground">{cityName}</span>
+          <span aria-hidden="true">/</span>
+          <span className="text-foreground font-medium">{cityName}</span>
         </nav>
         
         <h1 className="text-3xl font-bold tracking-tight mb-1">

--- a/src/app/[category]/[state]/page.tsx
+++ b/src/app/[category]/[state]/page.tsx
@@ -59,14 +59,14 @@ export default async function StatePage({ params }: PageProps) {
 
   return (
     <Container className="py-10">
-      <nav className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
-        <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
-        <span>/</span>
-        <Link href={`/categories/${categorySlug}`} className="hover:text-foreground transition-colors">
+      <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm text-muted-foreground mb-6">
+        <Link href="/" className="hover:text-foreground transition-colors underline underline-offset-4">Home</Link>
+        <span aria-hidden="true">/</span>
+        <Link href={`/categories/${categorySlug}`} className="hover:text-foreground transition-colors underline underline-offset-4">
           {categoryLabel}
         </Link>
-        <span>/</span>
-        <span className="text-foreground">{stateInfo.name}</span>
+        <span aria-hidden="true">/</span>
+        <span className="text-foreground font-medium">{stateInfo.name}</span>
       </nav>
 
       <div className="mb-8">


### PR DESCRIPTION
Fixes #46 — breadcrumbs on city pages not showing up.

**Changes:**
- Added `underline underline-offset-4` to all breadcrumb links on city and state pages
- Added `font-medium` to the current-page (non-link) breadcrumb step
- Added `aria-label="Breadcrumb"` to the nav for accessibility
- Added `aria-hidden="true"` to separator spans

This commit also forces Vercel to rebuild all statically-generated city/state pages, replacing any stale cached builds.

Closes #46

Generated with [Claude Code](https://claude.ai/code)