### PR TITLE
Fix data classification: filter misclassified businesses at import and in DB

### DIFF
--- a/junk_hauling_launcher.py
+++ b/junk_hauling_launcher.py
@@ -129,6 +129,37 @@ EXCLUDE_CATEGORIES = {
     "personal injury lawyer", "legal services",
     # Appraisers & inspectors
     "appraiser", "home inspector",
+    # Truck / trailer / vehicle rental — not hauling/removal services
+    "truck rental agency", "trailer rental service", "van rental agency",
+    "vehicle rental agency", "car rental agency", "moving truck rental agency",
+    # Self-storage — not the same as junk removal
+    "self storage facility", "storage facility", "mini storage facility",
+    "moving and storage service",
+    # Cleaning services that are not estate cleanout
+    "pressure washing service", "power washing service", "soft washing service",
+    "window cleaning service", "gutter cleaning service", "carpet cleaning service",
+    "car wash", "auto detailing service", "auto body shop",
+    # Auto / vehicle repair — irrelevant
+    "auto repair shop", "tire shop", "mechanic", "transmission shop",
+    "auto parts store",
+    # Home trades — not removal/cleanout
+    "plumber", "plumbing service", "electrician", "electrical installation service",
+    "hvac contractor", "air conditioning repair service", "heating contractor",
+    "roofer", "roofing company", "painter", "painting",
+    "flooring contractor", "flooring store", "tile contractor",
+    # Landscaping / pest — not removal/cleanout
+    "lawn care service", "landscaping service", "landscape architect",
+    "tree service", "tree trimming service", "stump removal service",
+    "pest control service", "exterminator",
+    # Food & hospitality
+    "restaurant", "cafe", "coffee shop", "fast food restaurant", "bar",
+    "hotel", "motel", "bed and breakfast",
+    "grocery store", "supermarket", "convenience store",
+    # Health & medical
+    "dentist", "dental clinic", "medical clinic", "pharmacy", "hospital",
+    "urgent care center", "doctor",
+    # Fuel & retail
+    "gas station", "fuel supplier", "department store", "clothing store",
 }
 
 def make_filenames(search_term):

--- a/src/lib/seed/import-csv-businesses.ts
+++ b/src/lib/seed/import-csv-businesses.ts
@@ -275,6 +275,55 @@ function parseAttributes(raw: string): Record<string, Record<string, boolean>> |
   }
 }
 
+// ── Category validation ───────────────────────────────────────────────────────
+
+// Google Maps categories that are never relevant to hauling/removal services.
+// The CSV 'category' column contains the Google Maps primary category name.
+// Any row whose category matches one of these is skipped at import time,
+// preventing non-relevant listings from polluting the directory.
+const EXCLUDED_GOOGLE_CATEGORIES = new Set([
+  // Truck / trailer / vehicle rental
+  'truck rental agency', 'trailer rental service', 'van rental agency',
+  'vehicle rental agency', 'car rental agency', 'moving truck rental agency',
+  // Self-storage
+  'self storage facility', 'storage facility', 'mini storage facility',
+  // Cleaning services that are not estate/junk related
+  'pressure washing service', 'power washing service', 'soft washing service',
+  'window cleaning service', 'gutter cleaning service', 'carpet cleaning service',
+  'car wash', 'auto detailing service', 'auto body shop',
+  // Auto / vehicle repair
+  'auto repair shop', 'tire shop', 'mechanic', 'transmission shop',
+  'auto parts store',
+  // Home trades
+  'plumber', 'plumbing service', 'electrician', 'electrical installation service',
+  'hvac contractor', 'air conditioning repair service', 'heating contractor',
+  'roofer', 'roofing company', 'painter', 'painting',
+  'flooring contractor', 'flooring store', 'tile contractor',
+  // Landscaping / pest
+  'lawn care service', 'landscaping service', 'landscape architect',
+  'tree service', 'tree trimming service', 'pest control service', 'exterminator',
+  // Real estate / finance
+  'real estate agency', 'real estate agent', 'real estate consultant',
+  'real estate attorney', 'real estate appraiser', 'estate agent',
+  'title company', 'mortgage lender', 'financial planner',
+  'insurance agency', 'accountant', 'lawyer', 'attorney',
+  // Food & hospitality
+  'restaurant', 'cafe', 'coffee shop', 'fast food restaurant', 'bar',
+  'hotel', 'motel',
+  // Health & medical
+  'dentist', 'dental clinic', 'medical clinic', 'pharmacy', 'hospital',
+  // Fuel & retail
+  'gas station', 'fuel supplier', 'department store', 'grocery store',
+  'supermarket', 'convenience store',
+])
+
+function isExcludedCategory(row: CsvRow): boolean {
+  // The 'category' column from Google Maps (primary category name).
+  // Rich format: row.category. Simple format: row.category.
+  const cat = (row.category ?? row.type ?? '').toLowerCase().trim()
+  return EXCLUDED_GOOGLE_CATEGORIES.has(cat)
+}
+
 // ── Main processing ───────────────────────────────────────────────────────────
 
 async function processCsvFile(
@@ -295,12 +344,16 @@ async function processCsvFile(
 
   const businesses: ProcessedBusiness[] = []
   let skipped = 0
+  let filtered = 0
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]
 
     const name = (isRichFormat ? row.name : row.business_name)?.trim()
     if (!name) { skipped++; continue }
+
+    // Skip businesses whose Google Maps category is clearly irrelevant
+    if (isExcludedCategory(row)) { filtered++; continue }
 
     // Use the actual business city, fall back to scraped_city (simple format only)
     const city = (row.city?.trim() || (!isRichFormat ? row.scraped_city?.trim() : ''))
@@ -362,7 +415,7 @@ async function processCsvFile(
     })
   }
 
-  console.log(`   ✅ ${businesses.length} valid businesses (${skipped} skipped)`)
+  console.log(`   ✅ ${businesses.length} valid businesses (${skipped} skipped, ${filtered} filtered by category)`)
   return businesses
 }
 

--- a/src/lib/seed/update-estate-cleanout.ts
+++ b/src/lib/seed/update-estate-cleanout.ts
@@ -166,6 +166,46 @@ function parseSocialMedia(row: CsvRow): Record<string, string> | undefined {
   return Object.keys(result).length > 0 ? result : undefined
 }
 
+// ── Category validation ───────────────────────────────────────────────────────
+
+// Google Maps categories that are never relevant to estate cleanout services.
+// The 'category' column in the simple CSV is the Google Maps primary category.
+const EXCLUDED_GOOGLE_CATEGORIES = new Set([
+  // Truck / trailer / vehicle rental
+  'truck rental agency', 'trailer rental service', 'van rental agency',
+  'vehicle rental agency', 'car rental agency', 'moving truck rental agency',
+  // Self-storage
+  'self storage facility', 'storage facility', 'mini storage facility',
+  // Cleaning services unrelated to estate/property cleanout
+  'pressure washing service', 'power washing service', 'soft washing service',
+  'window cleaning service', 'gutter cleaning service', 'carpet cleaning service',
+  'car wash', 'auto detailing service', 'auto body shop',
+  // Auto / vehicle repair
+  'auto repair shop', 'tire shop', 'mechanic', 'transmission shop',
+  'auto parts store',
+  // Home trades (not cleanout)
+  'plumber', 'plumbing service', 'electrician', 'electrical installation service',
+  'hvac contractor', 'air conditioning repair service', 'heating contractor',
+  'roofer', 'roofing company', 'painter', 'painting',
+  'flooring contractor', 'flooring store', 'tile contractor',
+  // Landscaping / pest
+  'lawn care service', 'landscaping service', 'landscape architect',
+  'tree service', 'tree trimming service', 'pest control service', 'exterminator',
+  // Real estate / finance
+  'real estate agency', 'real estate agent', 'real estate consultant',
+  'real estate attorney', 'real estate appraiser', 'estate agent',
+  'title company', 'mortgage lender', 'financial planner',
+  'insurance agency', 'accountant', 'lawyer', 'attorney',
+  // Food & hospitality
+  'restaurant', 'cafe', 'coffee shop', 'fast food restaurant', 'bar',
+  'hotel', 'motel',
+  // Health & medical
+  'dentist', 'dental clinic', 'medical clinic', 'pharmacy', 'hospital',
+  // Fuel & retail
+  'gas station', 'fuel supplier', 'department store', 'grocery store',
+  'supermarket', 'convenience store',
+])
+
 // ── Processing ────────────────────────────────────────────────────────────────
 
 async function parseCsv(filePath: string, existingSlugs: Set<string>): Promise<ProcessedBusiness[]> {
@@ -177,10 +217,15 @@ async function parseCsv(filePath: string, existingSlugs: Set<string>): Promise<P
   // Track which base slugs have been used and how many times
   const seenSlugs = new Map<string, number>()
   let skipped = 0
+  let filtered = 0
 
   for (const row of rows) {
     const name = row.business_name?.trim()
     if (!name) { skipped++; continue }
+
+    // Skip businesses whose Google Maps category is clearly irrelevant
+    const googleCat = (row.category ?? '').toLowerCase().trim()
+    if (EXCLUDED_GOOGLE_CATEGORIES.has(googleCat)) { filtered++; continue }
 
     const city = row.city?.trim() || row.scraped_city?.trim()
     if (!city) { skipped++; continue }
@@ -227,7 +272,7 @@ async function parseCsv(filePath: string, existingSlugs: Set<string>): Promise<P
     })
   }
 
-  console.log(`   ✅ ${businesses.length} valid (${skipped} skipped)`)
+  console.log(`   ✅ ${businesses.length} valid (${skipped} skipped, ${filtered} filtered by category)`)
   return businesses
 }
 

--- a/supabase/fix-misclassified-businesses.sql
+++ b/supabase/fix-misclassified-businesses.sql
@@ -1,0 +1,174 @@
+-- ============================================================
+-- Fix misclassified businesses
+-- Run this in the Supabase SQL editor to deactivate records
+-- that do not belong in their assigned category.
+--
+-- Safe: uses status='inactive' rather than DELETE so records
+-- can be reviewed before permanent removal.
+-- ============================================================
+
+-- ── Step 1: junk_removal — deactivate by irrelevant services JSONB ──────────
+-- Businesses imported from the rich-format CSV have a services JSONB column
+-- that stores Google Maps subtypes (e.g. "Truck rental agency").
+-- Mark inactive any junk_removal listing whose services contain ZERO
+-- junk-removal-relevant keywords.
+UPDATE businesses
+SET status = 'inactive'
+WHERE category = 'junk_removal'
+  AND services IS NOT NULL
+  AND jsonb_array_length(services) > 0
+  AND NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(services) AS svc
+    WHERE
+      lower(svc->>'name') LIKE '%junk%'       OR
+      lower(svc->>'name') LIKE '%debris%'     OR
+      lower(svc->>'name') LIKE '%removal%'    OR
+      lower(svc->>'name') LIKE '%haul%'       OR
+      lower(svc->>'name') LIKE '%waste%'      OR
+      lower(svc->>'name') LIKE '%garbage%'    OR
+      lower(svc->>'name') LIKE '%trash%'      OR
+      lower(svc->>'name') LIKE '%disposal%'   OR
+      lower(svc->>'name') LIKE '%recycl%'     OR
+      lower(svc->>'name') LIKE '%dumpster%'   OR
+      lower(svc->>'name') LIKE '%cleanout%'   OR
+      lower(svc->>'name') LIKE '%clean out%'  OR
+      lower(svc->>'name') LIKE '%sanitation%' OR
+      lower(svc->>'name') LIKE '%scrap%'
+  );
+
+-- ── Step 2: junk_removal — deactivate well-known truck-rental chains ────────
+-- Simple-format imports have no services JSONB; catch irrelevant businesses
+-- by recognisable brand names that have no place in a junk-removal directory.
+UPDATE businesses
+SET status = 'inactive'
+WHERE category = 'junk_removal'
+  AND status = 'active'
+  AND (
+    lower(name) LIKE '%u-haul%'          OR
+    lower(name) LIKE '%uhaul%'           OR
+    lower(name) LIKE '%penske%'          OR
+    lower(name) LIKE '%budget truck%'    OR
+    lower(name) LIKE '%ryder truck%'     OR
+    lower(name) LIKE '%national rental%' OR
+    lower(name) LIKE '%trailer rental%'  OR
+    lower(name) LIKE '%truck rental%'    OR
+    lower(name) LIKE '%self storage%'    OR
+    lower(name) LIKE '%public storage%'  OR
+    lower(name) LIKE '%extra space%'     OR
+    lower(name) LIKE '%life storage%'    OR
+    lower(name) LIKE '%cube smart%'
+  );
+
+-- ── Step 3: estate_cleanout — deactivate clearly irrelevant businesses ───────
+-- Estate-cleanout records from the simple-format CSV have no services JSONB,
+-- so we rely on business name keywords to identify misclassified entries.
+UPDATE businesses
+SET status = 'inactive'
+WHERE category = 'estate_cleanout'
+  AND status = 'active'
+  AND (
+    lower(name) LIKE '%pressure wash%'   OR
+    lower(name) LIKE '%power wash%'      OR
+    lower(name) LIKE '%soft wash%'       OR
+    lower(name) LIKE '%window clean%'    OR
+    lower(name) LIKE '%window wash%'     OR
+    lower(name) LIKE '%gutter clean%'    OR
+    lower(name) LIKE '%carpet clean%'    OR
+    lower(name) LIKE '%floor clean%'     OR
+    lower(name) LIKE '%car wash%'        OR
+    lower(name) LIKE '%auto detail%'     OR
+    lower(name) LIKE '%auto wash%'       OR
+    lower(name) LIKE '%auto repair%'     OR
+    lower(name) LIKE '%tire %'           OR
+    lower(name) LIKE '% tires%'          OR
+    lower(name) LIKE '%mechanic%'        OR
+    lower(name) LIKE '%transmission%'    OR
+    lower(name) LIKE '%pest control%'    OR
+    lower(name) LIKE '%exterminator%'    OR
+    lower(name) LIKE '%termite%'         OR
+    lower(name) LIKE '%lawn care%'       OR
+    lower(name) LIKE '%lawn service%'    OR
+    lower(name) LIKE '%landscap%'        OR
+    lower(name) LIKE '%tree service%'    OR
+    lower(name) LIKE '%tree trim%'       OR
+    lower(name) LIKE '%tree remov%'      OR
+    lower(name) LIKE '%stump%'           OR
+    lower(name) LIKE '%plumb%'           OR
+    lower(name) LIKE '%electrician%'     OR
+    lower(name) LIKE '%electric service%' OR
+    lower(name) LIKE '%hvac%'            OR
+    lower(name) LIKE '%air condition%'   OR
+    lower(name) LIKE '%furnace%'         OR
+    lower(name) LIKE '%roofing%'         OR
+    lower(name) LIKE '%roofer%'          OR
+    lower(name) LIKE '%painting%'        OR
+    lower(name) LIKE '%painters%'        OR
+    lower(name) LIKE '%flooring%'        OR
+    lower(name) LIKE '%hardwood floor%'  OR
+    lower(name) LIKE '%real estate%'     OR
+    lower(name) LIKE '%realty%'          OR
+    lower(name) LIKE '%realtor%'         OR
+    lower(name) LIKE '%insurance%'       OR
+    lower(name) LIKE '%financial%'       OR
+    lower(name) LIKE '%accounting%'      OR
+    lower(name) LIKE '%u-haul%'          OR
+    lower(name) LIKE '%uhaul%'           OR
+    lower(name) LIKE '%self storage%'    OR
+    lower(name) LIKE '%public storage%'  OR
+    lower(name) LIKE '%hotel%'           OR
+    lower(name) LIKE '%restaurant%'      OR
+    lower(name) LIKE '%dentist%'         OR
+    lower(name) LIKE '%dental%'          OR
+    lower(name) LIKE '%medical%'         OR
+    lower(name) LIKE '%clinic%'          OR
+    lower(name) LIKE '%pharmacy%'        OR
+    lower(name) LIKE '%gas station%'     OR
+    lower(name) LIKE '%fuel station%'    OR
+    lower(name) LIKE '%grocery%'         OR
+    lower(name) LIKE '%supermarket%'
+  );
+
+-- ── Step 4: estate_cleanout — deactivate by irrelevant services JSONB ────────
+-- For any estate_cleanout records that do have services stored.
+UPDATE businesses
+SET status = 'inactive'
+WHERE category = 'estate_cleanout'
+  AND status = 'active'
+  AND services IS NOT NULL
+  AND jsonb_array_length(services) > 0
+  AND NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(services) AS svc
+    WHERE
+      lower(svc->>'name') LIKE '%clean%'     OR
+      lower(svc->>'name') LIKE '%junk%'      OR
+      lower(svc->>'name') LIKE '%haul%'      OR
+      lower(svc->>'name') LIKE '%remov%'     OR
+      lower(svc->>'name') LIKE '%estate%'    OR
+      lower(svc->>'name') LIKE '%disposal%'  OR
+      lower(svc->>'name') LIKE '%moving%'    OR
+      lower(svc->>'name') LIKE '%mover%'     OR
+      lower(svc->>'name') LIKE '%auction%'   OR
+      lower(svc->>'name') LIKE '%liquidat%'  OR
+      lower(svc->>'name') LIKE '%debris%'    OR
+      lower(svc->>'name') LIKE '%storage%'
+  );
+
+-- ── Verification queries (run after above to review counts) ─────────────────
+
+-- How many businesses are now inactive?
+-- SELECT category, COUNT(*) AS inactive_count
+-- FROM businesses
+-- WHERE status = 'inactive'
+-- GROUP BY category;
+
+-- Preview what was deactivated before committing:
+-- SELECT id, name, city, state, category, services
+-- FROM businesses
+-- WHERE status = 'inactive'
+-- ORDER BY category, name
+-- LIMIT 50;
+
+-- To permanently delete all inactive businesses (run only after review):
+-- DELETE FROM businesses WHERE status = 'inactive';


### PR DESCRIPTION
Fixes #50

Two root causes identified and fixed:

1. Import scripts were assigning every row to a category regardless of the Google Maps primary category stored in the CSV. Unrelated businesses (pressure washers, U-Haul dealers, mechanics) slipped into the directory.

2. The scraper harvest filter only blocked real-estate and legal businesses.

Changes:
- `supabase/fix-misclassified-businesses.sql`: SQL to deactivate existing misclassified records (run in Supabase SQL editor)
- `import-csv-businesses.ts` / `update-estate-cleanout.ts`: added category validation at import time
- `junk_hauling_launcher.py`: expanded EXCLUDE_CATEGORIES with ~35 irrelevant Google Maps types

Generated with [Claude Code](https://claude.ai/code)