### PR TITLE
fix: replace incorrect junk removal stock photos

### DIFF
--- a/src/components/home/HeroSectionBrightA.tsx
+++ b/src/components/home/HeroSectionBrightA.tsx
@@ -12,7 +12,7 @@ function JunkRemovalCardA() {
       <div
         className="absolute inset-0"
         style={{
-          backgroundImage: 'url(https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=600&q=80)',
+          backgroundImage: 'url(https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=600&q=80)',
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}

--- a/src/components/home/HeroSectionBrightB.tsx
+++ b/src/components/home/HeroSectionBrightB.tsx
@@ -55,7 +55,7 @@ export function HeroSectionBrightB() {
               <div
                 className="absolute top-0 left-0 right-0 h-[72px]"
                 style={{
-                  backgroundImage: 'url(https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&q=70)',
+                  backgroundImage: 'url(https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=400&q=70)',
                   backgroundSize: 'cover',
                   backgroundPosition: 'center 30%',
                   borderRadius: '16px 16px 0 0',

--- a/src/components/home/HeroSectionBrightC.tsx
+++ b/src/components/home/HeroSectionBrightC.tsx
@@ -11,7 +11,7 @@ export function HeroSectionBrightC() {
           className="flex-none"
           style={{
             width: '38%',
-            backgroundImage: 'url(https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=800&q=80)',
+            backgroundImage: 'url(https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=800&q=80)',
             backgroundSize: 'cover',
             backgroundPosition: 'center',
           }}

--- a/src/components/home/HeroSectionBrightD.tsx
+++ b/src/components/home/HeroSectionBrightD.tsx
@@ -18,7 +18,7 @@ function JunkRemovalCardD() {
         className="absolute top-0 left-0 right-0"
         style={{
           height: 140,
-          backgroundImage: 'url(https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=600&q=80)',
+          backgroundImage: 'url(https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=600&q=80)',
           backgroundSize: 'cover',
           backgroundPosition: 'center 35%',
           borderRadius: '16px 16px 0 0',

--- a/src/components/listings/ListingCard.test.tsx
+++ b/src/components/listings/ListingCard.test.tsx
@@ -29,7 +29,7 @@ const mockBusiness: Business = {
     {
       id: 'img-1',
       business_id: 'test-id',
-      url: 'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=800&q=80',
+      url: 'https://images.unsplash.com/photo-1504307651254-35680f356dfd?w=800&q=80',
       alt_text: 'Junk removal truck',
       is_primary: true,
       sort_order: 0,

--- a/src/lib/seed/data.ts
+++ b/src/lib/seed/data.ts
@@ -31,13 +31,11 @@ interface SeedReview {
 // Curated Unsplash photo IDs for junk removal / estate cleanout
 export const PHOTOS = {
   junk: [
-    { id: '1558618666-fcd25c85cd64', alt: 'Junk removal truck loaded with debris' },
-    { id: '1530126174756-aeefa3b5c4ef', alt: 'Crew removing furniture from home' },
     { id: '1504307651254-35680f356dfd', alt: 'Dumpster bin for waste removal' },
+    { id: '1530126174756-aeefa3b5c4ef', alt: 'Crew removing furniture from home' },
     { id: '1581578731548-c64695cc6952', alt: 'Team clearing out garage clutter' },
     { id: '1530124566582-a618bc2615dc', alt: 'Junk removal professionals at work' },
     { id: '1517142089942-ba376ce32a2e', alt: 'Clean up crew hauling away trash' },
-    { id: '1558618047-3c8c76ca7d13', alt: 'Residential junk removal service' },
     { id: '1584622650111-993a426fbf0a', alt: 'Large item pickup service' },
   ],
   estate: [


### PR DESCRIPTION
Replaces the wellness bottle photo used as junk removal image with a verified dumpster/waste-bin photo across all hero sections and seed data.

Closes #55

Generated with [Claude Code](https://claude.ai/code)