### PR TITLE
fix: replace wrong junk removal image URLs in database

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "scrape-services": "npx ts-node -r dotenv/config --project tsconfig.seed.json src/lib/seed/scrape-services.ts",
     "import-csv": "npx ts-node -r dotenv/config --project tsconfig.seed.json src/lib/seed/import-csv-businesses.ts",
     "update-estate-cleanout": "npx ts-node -r dotenv/config --project tsconfig.seed.json src/lib/seed/update-estate-cleanout.ts",
+    "fix-junk-images": "npx ts-node -r dotenv/config --project tsconfig.seed.json src/lib/seed/fix-junk-images.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test"

--- a/src/lib/seed/fix-junk-images.ts
+++ b/src/lib/seed/fix-junk-images.ts
@@ -1,0 +1,57 @@
+import dotenv from 'dotenv'
+dotenv.config({ path: '.env.local' })
+
+import { createAdminClient } from '../supabase/admin'
+import { PHOTOS } from './data'
+
+// Photo IDs confirmed to show incorrect content (wellness bottles, not junk removal)
+const BAD_PHOTO_IDS = [
+  '1558618666-fcd25c85cd64',
+  '1558618047-3c8c76ca7d13',
+]
+
+async function run() {
+  const supabase = createAdminClient()
+  let totalFixed = 0
+
+  for (const badId of BAD_PHOTO_IDS) {
+    const { data: rows, error: fetchErr } = await supabase
+      .from('business_images')
+      .select('id')
+      .ilike('url', `%photo-${badId}%`)
+
+    if (fetchErr) {
+      console.error(`Error fetching images for ${badId}:`, fetchErr.message)
+      continue
+    }
+
+    const count = rows?.length ?? 0
+    console.log(`Found ${count} images with bad photo ID: ${badId}`)
+
+    if (count === 0) continue
+
+    for (let i = 0; i < rows!.length; i++) {
+      const poolEntry = PHOTOS.junk[i % PHOTOS.junk.length]
+      const newUrl = `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`
+
+      const { error: updateErr } = await supabase
+        .from('business_images')
+        .update({ url: newUrl, alt_text: poolEntry.alt })
+        .eq('id', rows![i].id)
+
+      if (updateErr) {
+        console.error(`Error updating image ${rows![i].id}:`, updateErr.message)
+      } else {
+        totalFixed++
+        console.log(`  ✅ Replaced ${badId} with ${poolEntry.id}`)
+      }
+    }
+  }
+
+  console.log(`\n✅ Done — fixed ${totalFixed} images`)
+}
+
+run().catch(err => {
+  console.error('❌ Fatal error:', err)
+  process.exit(1)
+})

--- a/src/lib/seed/seed.ts
+++ b/src/lib/seed/seed.ts
@@ -24,7 +24,16 @@ async function seed() {
   // Build slug→id map
   const slugToId = new Map(insertedBusinesses?.map((b) => [b.slug, b.id]) ?? [])
 
-  // Upsert images
+  // Replace images: delete existing then re-insert so stale URLs are never left behind
+  const bizIds = [...slugToId.values()]
+  if (bizIds.length > 0) {
+    const { error: delErr } = await supabase
+      .from('business_images')
+      .delete()
+      .in('business_id', bizIds)
+    if (delErr) console.warn('Image delete warning:', delErr.message)
+  }
+
   const imageRows = SEED_BUSINESSES.flatMap(({ slug, images }) => {
     const bizId = slugToId.get(slug)
     if (!bizId) return []
@@ -33,7 +42,7 @@ async function seed() {
 
   if (imageRows.length > 0) {
     const { error: imgError } = await supabase.from('business_images').insert(imageRows)
-    if (imgError && !imgError.message.includes('duplicate')) {
+    if (imgError) {
       console.warn('Image insert warning:', imgError.message)
     } else {
       console.log(`✅ Inserted ${imageRows.length} images`)


### PR DESCRIPTION
The previous fix removed bad Unsplash photo IDs from seed source code, but seed.ts used INSERT (not delete + re-insert) for images, so old wellness-bottle URLs persisted in the database.

- Add fix-junk-images.ts: one-shot migration to update business_images records still using the two bad photo IDs
- Fix seed.ts to delete existing images before re-inserting so future seed runs never leave stale wrong URLs behind

After merging, run `npm run fix-junk-images` with production credentials to patch the live database.

Closes #55

Generated with [Claude Code](https://claude.ai/code)