### PR TITLE
fix: improve fix-junk-images to catch all stale Unsplash photos

### DIFF
--- a/src/lib/seed/fix-junk-images.ts
+++ b/src/lib/seed/fix-junk-images.ts
@@ -4,51 +4,133 @@ dotenv.config({ path: '.env.local' })
 import { createAdminClient } from '../supabase/admin'
 import { PHOTOS } from './data'
 
-// Photo IDs confirmed to show incorrect content (wellness bottles, not junk removal)
-const BAD_PHOTO_IDS = [
-  '1558618666-fcd25c85cd64',
-  '1558618047-3c8c76ca7d13',
-]
+// The full set of approved Unsplash photo IDs for each category.
+// Any image whose URL contains an Unsplash photo ID NOT in these sets
+// is considered stale/wrong and will be replaced.
+const APPROVED_JUNK_IDS = new Set(PHOTOS.junk.map(p => p.id))
+const APPROVED_ESTATE_IDS = new Set(PHOTOS.estate.map(p => p.id))
+
+// Regex to extract the Unsplash photo ID from a URL like:
+// https://images.unsplash.com/photo-<ID>?w=800&q=80
+const UNSPLASH_PHOTO_RE = /photo-([a-z0-9-]+)\?/i
 
 async function run() {
   const supabase = createAdminClient()
   let totalFixed = 0
 
-  for (const badId of BAD_PHOTO_IDS) {
-    const { data: rows, error: fetchErr } = await supabase
-      .from('business_images')
-      .select('id')
-      .ilike('url', `%photo-${badId}%`)
+  // ── Junk removal ────────────────────────────────────────────────────────────
+  console.log('\n🔍 Scanning junk_removal business images for stale Unsplash photos…')
 
-    if (fetchErr) {
-      console.error(`Error fetching images for ${badId}:`, fetchErr.message)
-      continue
+  // Fetch all junk_removal business IDs
+  const { data: junkBizRows, error: bizErr } = await supabase
+    .from('businesses')
+    .select('id')
+    .eq('category', 'junk_removal')
+
+  if (bizErr) {
+    console.error('❌ Error fetching junk businesses:', bizErr.message)
+    process.exit(1)
+  }
+
+  const junkBizIds = (junkBizRows ?? []).map(r => r.id)
+  console.log(`   Found ${junkBizIds.length} junk_removal businesses`)
+
+  if (junkBizIds.length > 0) {
+    // Fetch all images for those businesses that are Unsplash URLs
+    const { data: imageRows, error: imgErr } = await supabase
+      .from('business_images')
+      .select('id, url, business_id, is_primary')
+      .in('business_id', junkBizIds)
+      .ilike('url', '%images.unsplash.com%')
+
+    if (imgErr) {
+      console.error('❌ Error fetching junk images:', imgErr.message)
+      process.exit(1)
     }
 
-    const count = rows?.length ?? 0
-    console.log(`Found ${count} images with bad photo ID: ${badId}`)
+    const stale = (imageRows ?? []).filter(row => {
+      const m = row.url.match(UNSPLASH_PHOTO_RE)
+      return m ? !APPROVED_JUNK_IDS.has(m[1]) : false
+    })
 
-    if (count === 0) continue
+    console.log(`   Stale images found: ${stale.length}`)
 
-    for (let i = 0; i < rows!.length; i++) {
+    for (let i = 0; i < stale.length; i++) {
+      const row = stale[i]
       const poolEntry = PHOTOS.junk[i % PHOTOS.junk.length]
       const newUrl = `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`
 
       const { error: updateErr } = await supabase
         .from('business_images')
         .update({ url: newUrl, alt_text: poolEntry.alt })
-        .eq('id', rows![i].id)
+        .eq('id', row.id)
 
       if (updateErr) {
-        console.error(`Error updating image ${rows![i].id}:`, updateErr.message)
+        console.error(`   ❌ Failed to update image ${row.id}:`, updateErr.message)
       } else {
+        const oldId = row.url.match(UNSPLASH_PHOTO_RE)?.[1] ?? '?'
+        console.log(`   ✅ Replaced ${oldId} → ${poolEntry.id}`)
         totalFixed++
-        console.log(`  ✅ Replaced ${badId} with ${poolEntry.id}`)
       }
     }
   }
 
-  console.log(`\n✅ Done — fixed ${totalFixed} images`)
+  // ── Estate cleanout ─────────────────────────────────────────────────────────
+  console.log('\n🔍 Scanning estate_cleanout business images for stale Unsplash photos…')
+
+  const { data: estateBizRows, error: estateBizErr } = await supabase
+    .from('businesses')
+    .select('id')
+    .eq('category', 'estate_cleanout')
+
+  if (estateBizErr) {
+    console.error('❌ Error fetching estate businesses:', estateBizErr.message)
+    process.exit(1)
+  }
+
+  const estateBizIds = (estateBizRows ?? []).map(r => r.id)
+  console.log(`   Found ${estateBizIds.length} estate_cleanout businesses`)
+
+  if (estateBizIds.length > 0) {
+    const { data: estateImageRows, error: estateImgErr } = await supabase
+      .from('business_images')
+      .select('id, url, business_id, is_primary')
+      .in('business_id', estateBizIds)
+      .ilike('url', '%images.unsplash.com%')
+
+    if (estateImgErr) {
+      console.error('❌ Error fetching estate images:', estateImgErr.message)
+      process.exit(1)
+    }
+
+    const stale = (estateImageRows ?? []).filter(row => {
+      const m = row.url.match(UNSPLASH_PHOTO_RE)
+      return m ? !APPROVED_ESTATE_IDS.has(m[1]) : false
+    })
+
+    console.log(`   Stale images found: ${stale.length}`)
+
+    for (let i = 0; i < stale.length; i++) {
+      const row = stale[i]
+      const poolEntry = PHOTOS.estate[i % PHOTOS.estate.length]
+      const newUrl = `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`
+
+      const { error: updateErr } = await supabase
+        .from('business_images')
+        .update({ url: newUrl, alt_text: poolEntry.alt })
+        .eq('id', row.id)
+
+      if (updateErr) {
+        console.error(`   ❌ Failed to update image ${row.id}:`, updateErr.message)
+      } else {
+        const oldId = row.url.match(UNSPLASH_PHOTO_RE)?.[1] ?? '?'
+        console.log(`   ✅ Replaced ${oldId} → ${poolEntry.id}`)
+        totalFixed++
+      }
+    }
+  }
+
+  console.log(`\n✅ Done — fixed ${totalFixed} stale images`)
 }
 
 run().catch(err => {


### PR DESCRIPTION
Rewrites the fix-junk-images.ts migration to detect any Unsplash photo ID not in the current approved pool, covering both junk_removal and estate_cleanout categories. Previous version only patched 2 hardcoded bad IDs.

After merging, run `npm run fix-junk-images` with production credentials to patch the live database.

Closes #55

Generated with [Claude Code](https://claude.ai/code)