### PR TITLE
fix: remove unverified junk photos, rewrite migration with batch upserts

### DIFF
--- a/src/lib/seed/data.ts
+++ b/src/lib/seed/data.ts
@@ -31,12 +31,10 @@ interface SeedReview {
 // Curated Unsplash photo IDs for junk removal / estate cleanout
 export const PHOTOS = {
   junk: [
+    // Only visually-verified photos belong here. The dumpster shot below is the
+    // sole confirmed junk-removal image (used in all four hero sections).
+    // Add more IDs only after visually confirming the Unsplash photo content.
     { id: '1504307651254-35680f356dfd', alt: 'Dumpster bin for waste removal' },
-    { id: '1530126174756-aeefa3b5c4ef', alt: 'Crew removing furniture from home' },
-    { id: '1581578731548-c64695cc6952', alt: 'Team clearing out garage clutter' },
-    { id: '1530124566582-a618bc2615dc', alt: 'Junk removal professionals at work' },
-    { id: '1517142089942-ba376ce32a2e', alt: 'Clean up crew hauling away trash' },
-    { id: '1584622650111-993a426fbf0a', alt: 'Large item pickup service' },
   ],
   estate: [
     { id: '1484154218962-a197022b6ac6', alt: 'Estate cleanout team at work' },

--- a/src/lib/seed/fix-junk-images.ts
+++ b/src/lib/seed/fix-junk-images.ts
@@ -4,133 +4,105 @@ dotenv.config({ path: '.env.local' })
 import { createAdminClient } from '../supabase/admin'
 import { PHOTOS } from './data'
 
-// The full set of approved Unsplash photo IDs for each category.
-// Any image whose URL contains an Unsplash photo ID NOT in these sets
-// is considered stale/wrong and will be replaced.
+// Any Unsplash photo ID NOT in these sets is considered stale and will be replaced.
+// Only add IDs after visually confirming the actual photo content on Unsplash.
 const APPROVED_JUNK_IDS = new Set(PHOTOS.junk.map(p => p.id))
 const APPROVED_ESTATE_IDS = new Set(PHOTOS.estate.map(p => p.id))
 
-// Regex to extract the Unsplash photo ID from a URL like:
-// https://images.unsplash.com/photo-<ID>?w=800&q=80
 const UNSPLASH_PHOTO_RE = /photo-([a-z0-9-]+)\?/i
+
+// Batch sizes to stay within Supabase PostgREST limits
+const BIZ_CHUNK = 500   // IDs per .in() when fetching images
+const UPD_CHUNK = 100   // rows per upsert batch
+
+async function fixCategory(
+  supabase: ReturnType<typeof createAdminClient>,
+  category: 'junk_removal' | 'estate_cleanout',
+  approvedIds: Set<string>,
+  pool: { id: string; alt: string }[]
+): Promise<number> {
+  console.log(`\n🔍 Scanning ${category} businesses…`)
+
+  // 1. Collect all business IDs for this category (paginated)
+  const bizIds: string[] = []
+  let from = 0
+  while (true) {
+    const { data, error } = await supabase
+      .from('businesses')
+      .select('id')
+      .eq('category', category)
+      .range(from, from + 999)
+    if (error) throw new Error(`Fetch businesses: ${error.message}`)
+    bizIds.push(...(data ?? []).map((r: { id: string }) => r.id))
+    if (!data || data.length < 1000) break
+    from += 1000
+  }
+  console.log(`   Found ${bizIds.length} businesses`)
+  if (bizIds.length === 0) return 0
+
+  // 2. Fetch all Unsplash image rows in chunks (avoids giant .in() clause)
+  const stale: { id: string; url: string }[] = []
+  for (let i = 0; i < bizIds.length; i += BIZ_CHUNK) {
+    const chunk = bizIds.slice(i, i + BIZ_CHUNK)
+    const { data: imgs, error: imgErr } = await supabase
+      .from('business_images')
+      .select('id, url')
+      .in('business_id', chunk)
+      .ilike('url', '%images.unsplash.com%')
+    if (imgErr) throw new Error(`Fetch images: ${imgErr.message}`)
+    for (const row of imgs ?? []) {
+      const m = (row.url as string).match(UNSPLASH_PHOTO_RE)
+      if (m && !approvedIds.has(m[1])) {
+        stale.push({ id: row.id, url: row.url })
+      }
+    }
+    if ((i / BIZ_CHUNK) % 4 === 0 && i > 0) {
+      console.log(`   … scanned ${i}/${bizIds.length} businesses, ${stale.length} stale so far`)
+    }
+  }
+
+  console.log(`   Stale images to replace: ${stale.length}`)
+  if (stale.length === 0) return 0
+
+  // 3. Replace stale images via batched upserts (cycles through the approved pool)
+  let fixed = 0
+  for (let i = 0; i < stale.length; i += UPD_CHUNK) {
+    const batchRows = stale.slice(i, i + UPD_CHUNK)
+    const upserts = batchRows.map((row, localIdx) => {
+      const poolEntry = pool[(i + localIdx) % pool.length]
+      return {
+        id: row.id,
+        url: `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`,
+        alt_text: poolEntry.alt,
+      }
+    })
+
+    const { error } = await supabase
+      .from('business_images')
+      .upsert(upserts, { onConflict: 'id' })
+
+    if (error) {
+      console.error(`   ❌ Upsert batch ${i}–${i + batchRows.length - 1} failed: ${error.message}`)
+    } else {
+      fixed += batchRows.length
+    }
+
+    if ((i / UPD_CHUNK) % 20 === 0 && i > 0) {
+      console.log(`   … fixed ${fixed}/${stale.length}`)
+    }
+  }
+
+  return fixed
+}
 
 async function run() {
   const supabase = createAdminClient()
-  let totalFixed = 0
 
-  // ── Junk removal ────────────────────────────────────────────────────────────
-  console.log('\n🔍 Scanning junk_removal business images for stale Unsplash photos…')
+  const junkFixed  = await fixCategory(supabase, 'junk_removal',   APPROVED_JUNK_IDS,   PHOTOS.junk)
+  const estateFixed = await fixCategory(supabase, 'estate_cleanout', APPROVED_ESTATE_IDS, PHOTOS.estate)
 
-  // Fetch all junk_removal business IDs
-  const { data: junkBizRows, error: bizErr } = await supabase
-    .from('businesses')
-    .select('id')
-    .eq('category', 'junk_removal')
-
-  if (bizErr) {
-    console.error('❌ Error fetching junk businesses:', bizErr.message)
-    process.exit(1)
-  }
-
-  const junkBizIds = (junkBizRows ?? []).map(r => r.id)
-  console.log(`   Found ${junkBizIds.length} junk_removal businesses`)
-
-  if (junkBizIds.length > 0) {
-    // Fetch all images for those businesses that are Unsplash URLs
-    const { data: imageRows, error: imgErr } = await supabase
-      .from('business_images')
-      .select('id, url, business_id, is_primary')
-      .in('business_id', junkBizIds)
-      .ilike('url', '%images.unsplash.com%')
-
-    if (imgErr) {
-      console.error('❌ Error fetching junk images:', imgErr.message)
-      process.exit(1)
-    }
-
-    const stale = (imageRows ?? []).filter(row => {
-      const m = row.url.match(UNSPLASH_PHOTO_RE)
-      return m ? !APPROVED_JUNK_IDS.has(m[1]) : false
-    })
-
-    console.log(`   Stale images found: ${stale.length}`)
-
-    for (let i = 0; i < stale.length; i++) {
-      const row = stale[i]
-      const poolEntry = PHOTOS.junk[i % PHOTOS.junk.length]
-      const newUrl = `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`
-
-      const { error: updateErr } = await supabase
-        .from('business_images')
-        .update({ url: newUrl, alt_text: poolEntry.alt })
-        .eq('id', row.id)
-
-      if (updateErr) {
-        console.error(`   ❌ Failed to update image ${row.id}:`, updateErr.message)
-      } else {
-        const oldId = row.url.match(UNSPLASH_PHOTO_RE)?.[1] ?? '?'
-        console.log(`   ✅ Replaced ${oldId} → ${poolEntry.id}`)
-        totalFixed++
-      }
-    }
-  }
-
-  // ── Estate cleanout ─────────────────────────────────────────────────────────
-  console.log('\n🔍 Scanning estate_cleanout business images for stale Unsplash photos…')
-
-  const { data: estateBizRows, error: estateBizErr } = await supabase
-    .from('businesses')
-    .select('id')
-    .eq('category', 'estate_cleanout')
-
-  if (estateBizErr) {
-    console.error('❌ Error fetching estate businesses:', estateBizErr.message)
-    process.exit(1)
-  }
-
-  const estateBizIds = (estateBizRows ?? []).map(r => r.id)
-  console.log(`   Found ${estateBizIds.length} estate_cleanout businesses`)
-
-  if (estateBizIds.length > 0) {
-    const { data: estateImageRows, error: estateImgErr } = await supabase
-      .from('business_images')
-      .select('id, url, business_id, is_primary')
-      .in('business_id', estateBizIds)
-      .ilike('url', '%images.unsplash.com%')
-
-    if (estateImgErr) {
-      console.error('❌ Error fetching estate images:', estateImgErr.message)
-      process.exit(1)
-    }
-
-    const stale = (estateImageRows ?? []).filter(row => {
-      const m = row.url.match(UNSPLASH_PHOTO_RE)
-      return m ? !APPROVED_ESTATE_IDS.has(m[1]) : false
-    })
-
-    console.log(`   Stale images found: ${stale.length}`)
-
-    for (let i = 0; i < stale.length; i++) {
-      const row = stale[i]
-      const poolEntry = PHOTOS.estate[i % PHOTOS.estate.length]
-      const newUrl = `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`
-
-      const { error: updateErr } = await supabase
-        .from('business_images')
-        .update({ url: newUrl, alt_text: poolEntry.alt })
-        .eq('id', row.id)
-
-      if (updateErr) {
-        console.error(`   ❌ Failed to update image ${row.id}:`, updateErr.message)
-      } else {
-        const oldId = row.url.match(UNSPLASH_PHOTO_RE)?.[1] ?? '?'
-        console.log(`   ✅ Replaced ${oldId} → ${poolEntry.id}`)
-        totalFixed++
-      }
-    }
-  }
-
-  console.log(`\n✅ Done — fixed ${totalFixed} stale images`)
+  const total = junkFixed + estateFixed
+  console.log(`\n✅ Done — fixed ${total} stale image(s) (${junkFixed} junk_removal, ${estateFixed} estate_cleanout)`)
 }
 
 run().catch(err => {


### PR DESCRIPTION
One of the 5 unverified Unsplash photo IDs in the junk pool was showing wellness supplement bottles. The migration kept reporting 0 stale images because the bad photo was inside the approved pool, not outside it.

- Reduces junk pool to the single visually confirmed dumpster photo used in all 4 hero sections
- Rewrites fix-junk-images.ts to chunk business-ID fetches (500 at a time) and use batched upserts (100 rows at a time) instead of one UPDATE per row

After merging, run `npm run fix-junk-images` with production credentials to patch the live database.

Closes #55

Generated with [Claude Code](https://claude.ai/code)