### PR TITLE
fix: scan ALL primary images in fix-junk-images (not just Unsplash URLs)

### DIFF
--- a/src/lib/seed/fix-junk-images.ts
+++ b/src/lib/seed/fix-junk-images.ts
@@ -4,23 +4,25 @@ dotenv.config({ path: '.env.local' })
 import { createAdminClient } from '../supabase/admin'
 import { PHOTOS } from './data'
 
-// Any Unsplash photo ID NOT in these sets is considered stale and will be replaced.
-// Only add IDs after visually confirming the actual photo content on Unsplash.
-const APPROVED_JUNK_IDS = new Set(PHOTOS.junk.map(p => p.id))
-const APPROVED_ESTATE_IDS = new Set(PHOTOS.estate.map(p => p.id))
-
-const UNSPLASH_PHOTO_RE = /photo-([a-z0-9-]+)\?/i
+// Build complete approved URL sets per category.
+// Any primary image NOT matching one of these exact URLs will be replaced.
+const APPROVED_JUNK_URLS = new Set(
+  PHOTOS.junk.map(p => `https://images.unsplash.com/photo-${p.id}?w=800&q=80`)
+)
+const APPROVED_ESTATE_URLS = new Set(
+  PHOTOS.estate.map(p => `https://images.unsplash.com/photo-${p.id}?w=800&q=80`)
+)
 
 // Batch sizes to stay within Supabase PostgREST limits
 const BIZ_CHUNK = 100   // IDs per .in() when fetching images
-const UPD_CHUNK = 100   // rows per upsert batch
+const UPD_CHUNK = 100   // rows per upsert/update batch
 
 async function fixCategory(
   supabase: ReturnType<typeof createAdminClient>,
   category: 'junk_removal' | 'estate_cleanout',
-  approvedIds: Set<string>,
+  approvedUrls: Set<string>,
   pool: { id: string; alt: string }[]
-): Promise<number> {
+): Promise<{ updated: number; inserted: number }> {
   console.log(`\n🔍 Scanning ${category} businesses…`)
 
   // 1. Collect all business IDs for this category (paginated)
@@ -38,71 +40,123 @@ async function fixCategory(
     from += 1000
   }
   console.log(`   Found ${bizIds.length} businesses`)
-  if (bizIds.length === 0) return 0
+  if (bizIds.length === 0) return { updated: 0, inserted: 0 }
 
-  // 2. Fetch all Unsplash image rows in chunks (avoids giant .in() clause)
-  const stale: { id: string; url: string }[] = []
+  // 2. Scan ALL images (any domain) for each chunk to find:
+  //    - bad primary images (wrong URL)
+  //    - businesses with no primary image at all
+  const toUpdateIds: string[] = []       // image row IDs whose URL needs fixing
+  const toInsertBizIds: string[] = []    // business IDs that have no primary image at all
+
   for (let i = 0; i < bizIds.length; i += BIZ_CHUNK) {
     const chunk = bizIds.slice(i, i + BIZ_CHUNK)
-    const { data: imgs, error: imgErr } = await supabase
+
+    // Fetch ALL images for these businesses — we check every primary regardless of domain
+    const { data: images, error } = await supabase
       .from('business_images')
-      .select('id, url')
+      .select('id, business_id, url, is_primary')
       .in('business_id', chunk)
-      .ilike('url', '%images.unsplash.com%')
-    if (imgErr) throw new Error(`Fetch images: ${imgErr.message}`)
-    for (const row of imgs ?? []) {
-      const m = (row.url as string).match(UNSPLASH_PHOTO_RE)
-      if (m && !approvedIds.has(m[1])) {
-        stale.push({ id: row.id, url: row.url })
+    if (error) throw new Error(`Fetch images: ${error.message}`)
+
+    // Group by business_id
+    const bizToImages = new Map<string, { id: string; url: string; is_primary: boolean }[]>()
+    for (const img of (images ?? []) as { id: string; business_id: string; url: string; is_primary: boolean }[]) {
+      if (!bizToImages.has(img.business_id)) bizToImages.set(img.business_id, [])
+      bizToImages.get(img.business_id)!.push(img)
+    }
+
+    for (const bizId of chunk) {
+      const imgs = bizToImages.get(bizId) ?? []
+      const primaryImg = imgs.find(img => img.is_primary)
+
+      if (!primaryImg) {
+        // No primary image at all — need to insert one
+        toInsertBizIds.push(bizId)
+      } else if (!approvedUrls.has(primaryImg.url)) {
+        // Primary image URL is NOT in the approved set — needs replacing
+        toUpdateIds.push(primaryImg.id)
       }
     }
-    if ((i / BIZ_CHUNK) % 4 === 0 && i > 0) {
-      console.log(`   … scanned ${i}/${bizIds.length} businesses, ${stale.length} stale so far`)
+
+    if ((i / BIZ_CHUNK) % 20 === 0 && i > 0) {
+      console.log(`   … scanned ${i}/${bizIds.length}: ${toUpdateIds.length} to update, ${toInsertBizIds.length} to insert`)
     }
   }
 
-  console.log(`   Stale images to replace: ${stale.length}`)
-  if (stale.length === 0) return 0
+  console.log(`   Primary images to replace: ${toUpdateIds.length}`)
+  console.log(`   Businesses missing primary:  ${toInsertBizIds.length}`)
 
-  // 3. Replace stale images via batched upserts (cycles through the approved pool)
-  let fixed = 0
-  for (let i = 0; i < stale.length; i += UPD_CHUNK) {
-    const batchRows = stale.slice(i, i + UPD_CHUNK)
-    const upserts = batchRows.map((row, localIdx) => {
-      const poolEntry = pool[(i + localIdx) % pool.length]
+  if (toUpdateIds.length === 0 && toInsertBizIds.length === 0) {
+    console.log(`   ✅ All primary images are already correct`)
+    return { updated: 0, inserted: 0 }
+  }
+
+  let updated = 0
+  let inserted = 0
+
+  // 3. Replace bad primary images via batched upserts (cycles through the approved pool)
+  for (let i = 0; i < toUpdateIds.length; i += UPD_CHUNK) {
+    const batch = toUpdateIds.slice(i, i + UPD_CHUNK)
+    const upserts = batch.map((imgId, localIdx) => {
+      const entry = pool[(i + localIdx) % pool.length]
       return {
-        id: row.id,
-        url: `https://images.unsplash.com/photo-${poolEntry.id}?w=800&q=80`,
-        alt_text: poolEntry.alt,
+        id: imgId,
+        url: `https://images.unsplash.com/photo-${entry.id}?w=800&q=80`,
+        alt_text: entry.alt,
       }
     })
-
     const { error } = await supabase
       .from('business_images')
       .upsert(upserts, { onConflict: 'id' })
-
     if (error) {
-      console.error(`   ❌ Upsert batch ${i}–${i + batchRows.length - 1} failed: ${error.message}`)
+      console.error(`   ❌ Update batch ${i}–${i + batch.length - 1} failed: ${error.message}`)
     } else {
-      fixed += batchRows.length
-    }
-
-    if ((i / UPD_CHUNK) % 20 === 0 && i > 0) {
-      console.log(`   … fixed ${fixed}/${stale.length}`)
+      updated += batch.length
+      if ((i / UPD_CHUNK) % 20 === 0 && i > 0) {
+        console.log(`   … updated ${updated}/${toUpdateIds.length}`)
+      }
     }
   }
 
-  return fixed
+  // 4. Insert primary images for businesses that had none at all
+  for (let i = 0; i < toInsertBizIds.length; i += UPD_CHUNK) {
+    const batch = toInsertBizIds.slice(i, i + UPD_CHUNK)
+    const rows = batch.map((bizId, localIdx) => {
+      const entry = pool[(i + localIdx) % pool.length]
+      return {
+        business_id: bizId,
+        url: `https://images.unsplash.com/photo-${entry.id}?w=800&q=80`,
+        alt_text: entry.alt,
+        is_primary: true,
+        sort_order: 0,
+      }
+    })
+    const { error } = await supabase
+      .from('business_images')
+      .insert(rows)
+    if (error) {
+      console.error(`   ❌ Insert batch ${i}–${i + batch.length - 1} failed: ${error.message}`)
+    } else {
+      inserted += batch.length
+    }
+  }
+
+  return { updated, inserted }
 }
 
 async function run() {
   const supabase = createAdminClient()
 
-  const junkFixed  = await fixCategory(supabase, 'junk_removal',   APPROVED_JUNK_IDS,   PHOTOS.junk)
-  const estateFixed = await fixCategory(supabase, 'estate_cleanout', APPROVED_ESTATE_IDS, PHOTOS.estate)
+  const junkResult  = await fixCategory(supabase, 'junk_removal',   APPROVED_JUNK_URLS,  PHOTOS.junk)
+  const estateResult = await fixCategory(supabase, 'estate_cleanout', APPROVED_ESTATE_URLS, PHOTOS.estate)
 
-  const total = junkFixed + estateFixed
-  console.log(`\n✅ Done — fixed ${total} stale image(s) (${junkFixed} junk_removal, ${estateFixed} estate_cleanout)`)
+  const totalUpdated  = junkResult.updated  + estateResult.updated
+  const totalInserted = junkResult.inserted + estateResult.inserted
+
+  console.log(`\n✅ Done!`)
+  console.log(`   junk_removal:    ${junkResult.updated} replaced, ${junkResult.inserted} inserted`)
+  console.log(`   estate_cleanout: ${estateResult.updated} replaced, ${estateResult.inserted} inserted`)
+  console.log(`   Total: ${totalUpdated} replaced, ${totalInserted} inserted`)
 }
 
 run().catch(err => {


### PR DESCRIPTION
Previous migration only checked images.unsplash.com URLs, silently skipping Google Maps / CDN primary images from imported CSV data. The migration kept reporting "0 stale images" while the supplement bottle photo remained visible.

The rewrite fetches ALL images for each business (any domain), checks if the primary image URL is in the approved set, and replaces or inserts the correct dumpster photo. Covers both junk_removal and estate_cleanout.

After merging, run `npm run fix-junk-images` with production credentials.

Closes #55

Generated with [Claude Code](https://claude.ai/code)